### PR TITLE
Webpack patch identifiers

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,14 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "type": "shell",
+      "command": "pnpm run build",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/packages/core/src/patch.ts
+++ b/packages/core/src/patch.ts
@@ -74,6 +74,13 @@ function patchModules(entry: WebpackJsonpEntry[1]) {
           replace.type === undefined ||
           replace.type === PatchReplaceType.Normal
         ) {
+          // Add support for \i to match rspack's minified names
+          if (typeof replace.match !== "string") {
+            replace.match = new RegExp(
+              replace.match.source.replace(/\\i/g, "[A-Za-z_$][\\w$]*"),
+              replace.match.flags
+            );
+          }
           // tsc fails to detect the overloads for this, so I'll just do this
           // Verbose, but it works
           let replaced;


### PR DESCRIPTION
Adds support for `\i`, which translates to [A-Za-z_$][\\w$]*