### PR TITLE
spacepack: filter real function

### DIFF
--- a/packages/core-extensions/src/spacepack/webpackModules/spacepack.ts
+++ b/packages/core-extensions/src/spacepack/webpackModules/spacepack.ts
@@ -176,6 +176,10 @@ export const spacepack: Spacepack = {
 
     const matchId = matchResult[1];
     return webpackRequire.el(matchId).then(() => webpackRequire(matchId));
+  },
+
+  filterReal: (modules: WebpackModule[]) => {
+    return modules.filter((module) => module.id.toString().match(/^\d+$/));
   }
 };
 

--- a/packages/types/src/coreExtensions.ts
+++ b/packages/types/src/coreExtensions.ts
@@ -2,7 +2,11 @@ import { FluxDefault, Store } from "./discord/common/Flux";
 import { CommonComponents as CommonComponents_ } from "./coreExtensions/components";
 import { Dispatcher } from "flux";
 import React from "react";
-import { WebpackModuleFunc, WebpackRequireType } from "./discord";
+import {
+  WebpackModule,
+  WebpackModuleFunc,
+  WebpackRequireType
+} from "./discord";
 
 export type Spacepack = {
   inspect: (module: number | string) => WebpackModuleFunc | null;
@@ -27,6 +31,7 @@ export type Spacepack = {
     find: string | RegExp | (string | RegExp)[],
     match: RegExp
   ) => Promise<any>;
+  filterReal: (modules: WebpackModule[]) => WebpackModule[];
 };
 
 export type NoticeProps = {


### PR DESCRIPTION
Adds spacepack.filterReal, which takes an array of webpack modules and returns modules that id is just numbers.

This is intended so you dont match yourself in a webpack module