### PR TITLE
moonbase: Implement multiline text input for settings

### DIFF
--- a/packages/core-extensions/src/moonbase/index.tsx
+++ b/packages/core-extensions/src/moonbase/index.tsx
@@ -38,5 +38,6 @@ export const webpackModules: ExtensionWebExports["webpackModules"] = {
 };
 
 export const styles = [
-  ".moonbase-settings > :first-child { margin-top: 0px; }"
+  ".moonbase-settings > :first-child { margin-top: 0px; }",
+  "textarea.moonbase-resizeable  { resize: vertical }"
 ];

--- a/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/settings.tsx
+++ b/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/settings.tsx
@@ -122,7 +122,7 @@ function String({ ext, name, setting, disabled }: SettingsProps) {
   );
 }
 
-function MultilineTextInput({ ext, name, setting, disabled }: SettingsProps) {
+function MultilineString({ ext, name, setting, disabled }: SettingsProps) {
   const { FormItem, FormText, TextArea } = CommonComponents;
   const { value, displayName, description } = useConfigEntry<string>(
     ext.id,
@@ -395,7 +395,7 @@ function Setting({ ext, name, setting, disabled }: SettingsProps) {
     [ExtensionSettingType.Boolean]: Boolean,
     [ExtensionSettingType.Number]: Number,
     [ExtensionSettingType.String]: String,
-    [ExtensionSettingType.MultilineTextInput]: MultilineTextInput,
+    [ExtensionSettingType.MultilineString]: MultilineString,
     [ExtensionSettingType.Select]: Select,
     [ExtensionSettingType.MultiSelect]: MultiSelect,
     [ExtensionSettingType.List]: List,

--- a/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/settings.tsx
+++ b/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/settings.tsx
@@ -122,6 +122,31 @@ function String({ ext, name, setting, disabled }: SettingsProps) {
   );
 }
 
+function MultilineTextInput({ ext, name, setting, disabled }: SettingsProps) {
+  const { FormItem, FormText, TextArea } = CommonComponents;
+  const { value, displayName, description } = useConfigEntry<string>(
+    ext.id,
+    name
+  );
+
+  return (
+    <FormItem className={Margins.marginTop20} title={displayName}>
+      {description && (
+        <FormText className={Margins.marginBottom8}>{description}</FormText>
+      )}
+      <TextArea
+        rows={5}
+        value={value ?? ""}
+        className={"moonbase-resizeable"}
+        onChange={(value: string) => {
+          if (disabled) return;
+          MoonbaseSettingsStore.setExtensionConfig(ext.id, name, value);
+        }}
+      />
+    </FormItem>
+  );
+}
+
 function Select({ ext, name, setting, disabled }: SettingsProps) {
   const { FormItem, FormText, SingleSelect } = CommonComponents;
   const { value, displayName, description } = useConfigEntry<string>(
@@ -370,6 +395,7 @@ function Setting({ ext, name, setting, disabled }: SettingsProps) {
     [ExtensionSettingType.Boolean]: Boolean,
     [ExtensionSettingType.Number]: Number,
     [ExtensionSettingType.String]: String,
+    [ExtensionSettingType.MultilineTextInput]: MultilineTextInput,
     [ExtensionSettingType.Select]: Select,
     [ExtensionSettingType.MultiSelect]: MultiSelect,
     [ExtensionSettingType.List]: List,

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -19,7 +19,7 @@ export enum ExtensionSettingType {
   Boolean = "boolean",
   Number = "number",
   String = "string",
-  MultilineTextInput = "multilinetextinput",
+  MultilineString = "multilinestring",
   Select = "select",
   MultiSelect = "multiselect",
   List = "list",
@@ -52,7 +52,7 @@ export type StringSettingType = {
 };
 
 export type MultilineTextInputSettingType = {
-  type: ExtensionSettingType.MultilineTextInput;
+  type: ExtensionSettingType.MultilineString;
   default?: string;
 };
 

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -19,6 +19,7 @@ export enum ExtensionSettingType {
   Boolean = "boolean",
   Number = "number",
   String = "string",
+  MultilineTextInput = "multilinetextinput",
   Select = "select",
   MultiSelect = "multiselect",
   List = "list",
@@ -47,6 +48,11 @@ export type NumberSettingType = {
 
 export type StringSettingType = {
   type: ExtensionSettingType.String;
+  default?: string;
+};
+
+export type MultilineTextInputSettingType = {
+  type: ExtensionSettingType.MultilineTextInput;
   default?: string;
 };
 
@@ -84,6 +90,7 @@ export type ExtensionSettingsManifest = {
   | BooleanSettingType
   | NumberSettingType
   | StringSettingType
+  | MultilineTextInputSettingType
   | SelectSettingType
   | MultiSelectSettingType
   | ListSettingType

--- a/packages/types/src/coreExtensions/components.ts
+++ b/packages/types/src/coreExtensions/components.ts
@@ -43,6 +43,50 @@ interface TextInput
   Sizes: typeof TextInputSizes;
 }
 
+export enum TextAreaAutoComplete {
+  ON = "on",
+  OFF = "off"
+}
+
+export enum TextAreaWrap {
+  HARD = "hard",
+  SOFT = "soft",
+  OFF = "off"
+}
+
+interface TextArea
+  extends ComponentClass<
+    PropsWithoutRef<{
+      value?: string;
+      defaultValue?: string;
+      autoComplete?: TextAreaAutoComplete;
+      autoFocus?: boolean;
+      cols?: number;
+      disabled?: boolean;
+      form?: string;
+      maxLength?: number;
+      minLength?: number;
+      name?: string;
+      onChange?: (value: string, name: string) => void;
+      onChangeCapture?: (value: string, name: string) => void;
+      onInput?: (value: string, name: string) => void;
+      onInputCapture?: (value: string, name: string) => void;
+      onInvalid?: (value: string, name: string) => void;
+      onInvalidCapture?: (value: string, name: string) => void;
+      onSelect?: (value: string, name: string) => void;
+      onSelectCapture?: (value: string, name: string) => void;
+      placeholder?: string;
+      readOnly?: boolean;
+      required?: boolean;
+      rows?: number;
+      wrap?: TextAreaWrap;
+      className?: string;
+    }>
+  > {
+  AutoCompletes: typeof TextAreaAutoComplete;
+  Wraps: typeof TextAreaWrap;
+}
+
 export enum FormTextTypes {
   DEFAULT = "default",
   DESCRIPTION = "description",
@@ -238,6 +282,7 @@ export type CommonComponents = {
     }>
   >;
   TextInput: TextInput;
+  TextArea: TextArea;
   FormDivider: ComponentClass<any>;
   FormSection: ComponentClass<
     PropsWithChildren<{


### PR DESCRIPTION
This adds the ability for extensions to have a multiline string setting in moonbase, mostly based off of the String setting type but using TextArea so it can be multiline

Looks like this:
![image](https://github.com/moonlight-mod/moonlight/assets/15057172/a2947506-8ce6-475b-93b6-ade3ef4bac90)
