### PR TITLE
Canary fixes

### DIFF
--- a/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/filterBar.tsx
+++ b/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/filterBar.tsx
@@ -38,8 +38,8 @@ const channelModule =
       '"Missing channel in Channel.openChannelContextMenu"'
     )[0].id
   ].toString();
-const moduleId = channelModule.match(/webpackId:"(.+?)"/)![1];
-const modPromise = spacepack.require.el(moduleId);
+const chunkId = channelModule.match(/createPromise:\(\)=>.\.el\("(.+?)"/)![1];
+const modPromise = spacepack.require.el(chunkId);
 
 const Margins = spacepack.findByCode("marginCenterHorz:")[0].exports;
 const SortMenuClasses = spacepack.findByCode("container:", "clearText:")[0]

--- a/packages/core-extensions/src/noTrack/index.ts
+++ b/packages/core-extensions/src/noTrack/index.ts
@@ -2,10 +2,10 @@ import { Patch } from "@moonlight-mod/types";
 
 export const patches: Patch[] = [
   {
-    find: "analyticsTrackingStoreMaker:function",
+    find: 'displayName="AnalyticsTrackingStore"',
     replace: {
       match: /analyticsTrackingStoreMaker:function\(\){return .}/,
-      replacement: "analyticsTrackingStoreMaker:function(){return ()=>{}}"
+      replacement: "analyticsTrackingStoreMaker:function(){return()=>{}}"
     }
   },
   {

--- a/packages/core-extensions/src/quietLoggers/index.ts
+++ b/packages/core-extensions/src/quietLoggers/index.ts
@@ -31,7 +31,7 @@ const stubPatches = [
   // "sh" is not a valid locale.
   [
     "is not a valid locale",
-    /(.)\.error\(""\.concat\((.)," is not a valid locale\."\)\)/g
+    /(.)\.error\(`\$\{.{1,2}\} is not a valid locale\.`\)/g
   ],
   ['.displayName="RunningGameStore"', /.\.info\("games",{.+?}\),/],
   [
@@ -50,7 +50,7 @@ const stubPatches = [
     '"[NATIVE INFO] ',
     /new\(0,.{1,2}\.default\)\(\)\.log\("\[NATIVE INFO] .+?\)\),/
   ],
-  ['"Spellchecker"', /.\.info\("Switching to ".+?"\(unavailable\)"\);?/g],
+  ['"Spellchecker"', /.\.info\(`Switching to .+?"\(unavailable\)"\);?/g],
   [
     'throw new Error("Messages are still loading.");',
     /console\.warn\("Unsupported Locale",.\);/
@@ -65,7 +65,7 @@ const stubPatches = [
     'Error("Messages are still loading.")',
     /console\.warn\("Unsupported Locale",.\),/
   ],
-  ['("DatabaseManager")', /.\.log\("removing database \(user: ".+?\)\),/],
+  ['("DatabaseManager")', /.\.log\(`removing database .+?`\),/],
   [
     '"Dispatch.dispatch(...): Cannot dispatch in the middle of a dispatch. Action: "',
     /.\.has\(.\.type\)&&.\.log\(.+?\.type\)\),/

--- a/packages/core-extensions/src/settings/index.ts
+++ b/packages/core-extensions/src/settings/index.ts
@@ -5,9 +5,9 @@ export const patches: Patch[] = [
   {
     find: ".UserSettingsSections.HOTSPOT_OPTIONS",
     replace: {
-      match: /\.CUSTOM,element:(.+?)}\];return (.{1,2})/,
-      replacement: (_, lastElement, sections) =>
-        `.CUSTOM,element:${lastElement}}];return require("settings_settings").Settings._mutateSections(${sections})`
+      match: /(?<=return)\[(?:.+?)\}\]/,
+      replacement: (sections: string) =>
+        ` require("settings_settings").Settings._mutateSections(${sections})`
     }
   },
   {


### PR DESCRIPTION
- settings: fix section injection
- moonbase: fix lazy chunk loading
- noTrack: fix analytics store patch
- quietLoggers: fix a few patches with template literals

These fixes are not backwards compatible, not sure if you want to merge this right now.
