### PR TITLE
moonbase: Use unique IDs for extension management

### DIFF
--- a/packages/core-extensions/src/moonbase/types.ts
+++ b/packages/core-extensions/src/moonbase/types.ts
@@ -40,6 +40,7 @@ export enum ExtensionState {
 
 export type MoonbaseExtension = {
   id: string;
+  uniqueId: number;
   manifest: ExtensionManifest | RepositoryManifest;
   source: DetectedExtension["source"];
   state: ExtensionState;

--- a/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/card.tsx
+++ b/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/card.tsx
@@ -36,18 +36,19 @@ const DangerIcon =
 const PanelButton =
   spacepack.findByCode("Masks.PANEL_BUTTON")[0].exports.default;
 
-export default function ExtensionCard({ id }: { id: string }) {
+export default function ExtensionCard({ uniqueId }: { uniqueId: number }) {
   const [tab, setTab] = React.useState(ExtensionPage.Info);
   const [restartNeeded, setRestartNeeded] = React.useState(false);
 
-  const { ext, enabled, busy, update } = Flux.useStateFromStores(
+  const { ext, enabled, busy, update, conflicting } = Flux.useStateFromStores(
     [MoonbaseSettingsStore],
     () => {
       return {
-        ext: MoonbaseSettingsStore.getExtension(id),
-        enabled: MoonbaseSettingsStore.getExtensionEnabled(id),
+        ext: MoonbaseSettingsStore.getExtension(uniqueId),
+        enabled: MoonbaseSettingsStore.getExtensionEnabled(uniqueId),
         busy: MoonbaseSettingsStore.busy,
-        update: MoonbaseSettingsStore.getExtensionUpdate(id)
+        update: MoonbaseSettingsStore.getExtensionUpdate(uniqueId),
+        conflicting: MoonbaseSettingsStore.getExtensionConflicting(uniqueId)
       };
     }
   );
@@ -96,8 +97,9 @@ export default function ExtensionCard({ id }: { id: string }) {
             <Button
               color={Button.Colors.BRAND}
               submitting={busy}
+              disabled={conflicting}
               onClick={() => {
-                MoonbaseSettingsStore.installExtension(id);
+                MoonbaseSettingsStore.installExtension(uniqueId);
               }}
             >
               Install
@@ -116,7 +118,7 @@ export default function ExtensionCard({ id }: { id: string }) {
                   icon={TrashIcon}
                   tooltipText="Delete"
                   onClick={() => {
-                    MoonbaseSettingsStore.deleteExtension(id);
+                    MoonbaseSettingsStore.deleteExtension(uniqueId);
                   }}
                 />
               )}
@@ -126,7 +128,7 @@ export default function ExtensionCard({ id }: { id: string }) {
                   icon={DownloadIcon}
                   tooltipText="Update"
                   onClick={() => {
-                    MoonbaseSettingsStore.installExtension(id);
+                    MoonbaseSettingsStore.installExtension(uniqueId);
                   }}
                 />
               )}
@@ -147,7 +149,7 @@ export default function ExtensionCard({ id }: { id: string }) {
                 checked={enabled}
                 onChange={() => {
                   setRestartNeeded(true);
-                  MoonbaseSettingsStore.setExtensionEnabled(id, !enabled);
+                  MoonbaseSettingsStore.setExtensionEnabled(uniqueId, !enabled);
                 }}
               />
             </div>

--- a/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/index.tsx
+++ b/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/index.tsx
@@ -14,13 +14,14 @@ const SearchBar = spacepack.findByCode("Messages.SEARCH", "hideSearchIcon")[0]
   .exports.default;
 
 export default function ExtensionsPage() {
+  const moonbaseId = MoonbaseSettingsStore.getExtensionUniqueId("moonbase")!;
   const { extensions, savedFilter } = Flux.useStateFromStoresObject(
     [MoonbaseSettingsStore],
     () => {
       return {
         extensions: MoonbaseSettingsStore.extensions,
         savedFilter: MoonbaseSettingsStore.getExtensionConfig(
-          "moonbase",
+          moonbaseId,
           "filter"
         )
       };
@@ -33,7 +34,7 @@ export default function ExtensionsPage() {
   if (moonlight.getConfigOption<boolean>("moonbase", "saveFilter")) {
     filter = savedFilter ?? defaultFilter;
     setFilter = (filter) =>
-      MoonbaseSettingsStore.setExtensionConfig("moonbase", "filter", filter);
+      MoonbaseSettingsStore.setExtensionConfig(moonbaseId, "filter", filter);
   } else {
     const state = React.useState(defaultFilter);
     filter = state[0];
@@ -63,9 +64,9 @@ export default function ExtensionsPage() {
         (!(filter & Filter.Developer) &&
           ext.source.type === ExtensionLoadSource.Developer) ||
         (!(filter & Filter.Enabled) &&
-          MoonbaseSettingsStore.getExtensionEnabled(ext.id)) ||
+          MoonbaseSettingsStore.getExtensionEnabled(ext.uniqueId)) ||
         (!(filter & Filter.Disabled) &&
-          !MoonbaseSettingsStore.getExtensionEnabled(ext.id)) ||
+          !MoonbaseSettingsStore.getExtensionEnabled(ext.uniqueId)) ||
         (!(filter & Filter.Installed) &&
           ext.state !== ExtensionState.NotDownloaded) ||
         (!(filter & Filter.Repository) &&
@@ -97,7 +98,7 @@ export default function ExtensionsPage() {
         />
       </React.Suspense>
       {filtered.map((ext) => (
-        <ExtensionCard id={ext.id} key={ext.id} />
+        <ExtensionCard uniqueId={ext.uniqueId} key={ext.id} />
       ))}
     </>
   );

--- a/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/info.tsx
+++ b/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/info.tsx
@@ -180,7 +180,11 @@ export default function ExtensionInfo({ ext }: { ext: MoonbaseExtension }) {
               [DependencyType.Incompatible]: "var(--red-400)"
             };
             const color = colors[dep.type];
-            const name = MoonbaseSettingsStore.getExtensionName(dep.id);
+            const id = MoonbaseSettingsStore.getExtensionUniqueId(dep.id);
+            const name =
+              (id !== null
+                ? MoonbaseSettingsStore.getExtensionName(id!)
+                : null) ?? dep.id;
             return (
               <Badge color={color} key={dep.id}>
                 {name}

--- a/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/settings.tsx
+++ b/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/settings.tsx
@@ -31,27 +31,30 @@ import { MoonbaseSettingsStore } from "@moonlight-mod/wp/moonbase_stores";
 
 const Margins = spacepack.findByCode("marginCenterHorz:")[0].exports;
 
-function useConfigEntry<T>(id: string, name: string) {
+function useConfigEntry<T>(uniqueId: number, name: string) {
   return Flux.useStateFromStores(
     [MoonbaseSettingsStore],
     () => {
       return {
-        value: MoonbaseSettingsStore.getExtensionConfig<T>(id, name),
-        displayName: MoonbaseSettingsStore.getExtensionConfigName(id, name),
+        value: MoonbaseSettingsStore.getExtensionConfig<T>(uniqueId, name),
+        displayName: MoonbaseSettingsStore.getExtensionConfigName(
+          uniqueId,
+          name
+        ),
         description: MoonbaseSettingsStore.getExtensionConfigDescription(
-          id,
+          uniqueId,
           name
         )
       };
     },
-    [id, name]
+    [uniqueId, name]
   );
 }
 
 function Boolean({ ext, name, setting, disabled }: SettingsProps) {
   const { FormSwitch } = CommonComponents;
   const { value, displayName, description } = useConfigEntry<boolean>(
-    ext.id,
+    ext.uniqueId,
     name
   );
 
@@ -61,7 +64,7 @@ function Boolean({ ext, name, setting, disabled }: SettingsProps) {
       hideBorder={true}
       disabled={disabled}
       onChange={(value: boolean) => {
-        MoonbaseSettingsStore.setExtensionConfig(ext.id, name, value);
+        MoonbaseSettingsStore.setExtensionConfig(ext.uniqueId, name, value);
       }}
       note={description}
       className={`${Margins.marginReset} ${Margins.marginTop20}`}
@@ -74,7 +77,7 @@ function Boolean({ ext, name, setting, disabled }: SettingsProps) {
 function Number({ ext, name, setting, disabled }: SettingsProps) {
   const { FormItem, FormText, Slider } = CommonComponents;
   const { value, displayName, description } = useConfigEntry<number>(
-    ext.id,
+    ext.uniqueId,
     name
   );
 
@@ -92,7 +95,7 @@ function Number({ ext, name, setting, disabled }: SettingsProps) {
         maxValue={castedSetting.max ?? 100}
         onValueChange={(value: number) => {
           const rounded = Math.max(min, Math.min(max, Math.round(value)));
-          MoonbaseSettingsStore.setExtensionConfig(ext.id, name, rounded);
+          MoonbaseSettingsStore.setExtensionConfig(ext.uniqueId, name, rounded);
         }}
       />
     </FormItem>
@@ -102,7 +105,7 @@ function Number({ ext, name, setting, disabled }: SettingsProps) {
 function String({ ext, name, setting, disabled }: SettingsProps) {
   const { FormItem, FormText, TextInput } = CommonComponents;
   const { value, displayName, description } = useConfigEntry<string>(
-    ext.id,
+    ext.uniqueId,
     name
   );
 
@@ -115,7 +118,7 @@ function String({ ext, name, setting, disabled }: SettingsProps) {
         value={value ?? ""}
         onChange={(value: string) => {
           if (disabled) return;
-          MoonbaseSettingsStore.setExtensionConfig(ext.id, name, value);
+          MoonbaseSettingsStore.setExtensionConfig(ext.uniqueId, name, value);
         }}
       />
     </FormItem>
@@ -125,7 +128,7 @@ function String({ ext, name, setting, disabled }: SettingsProps) {
 function MultilineString({ ext, name, setting, disabled }: SettingsProps) {
   const { FormItem, FormText, TextArea } = CommonComponents;
   const { value, displayName, description } = useConfigEntry<string>(
-    ext.id,
+    ext.uniqueId,
     name
   );
 
@@ -140,7 +143,7 @@ function MultilineString({ ext, name, setting, disabled }: SettingsProps) {
         className={"moonbase-resizeable"}
         onChange={(value: string) => {
           if (disabled) return;
-          MoonbaseSettingsStore.setExtensionConfig(ext.id, name, value);
+          MoonbaseSettingsStore.setExtensionConfig(ext.uniqueId, name, value);
         }}
       />
     </FormItem>
@@ -150,7 +153,7 @@ function MultilineString({ ext, name, setting, disabled }: SettingsProps) {
 function Select({ ext, name, setting, disabled }: SettingsProps) {
   const { FormItem, FormText, SingleSelect } = CommonComponents;
   const { value, displayName, description } = useConfigEntry<string>(
-    ext.id,
+    ext.uniqueId,
     name
   );
 
@@ -171,7 +174,7 @@ function Select({ ext, name, setting, disabled }: SettingsProps) {
         )}
         onChange={(value: string) => {
           if (disabled) return;
-          MoonbaseSettingsStore.setExtensionConfig(ext.id, name, value);
+          MoonbaseSettingsStore.setExtensionConfig(ext.uniqueId, name, value);
         }}
       />
     </FormItem>
@@ -182,7 +185,7 @@ function MultiSelect({ ext, name, setting, disabled }: SettingsProps) {
   const { FormItem, FormText, Select, useVariableSelect, multiSelect } =
     CommonComponents;
   const { value, displayName, description } = useConfigEntry<string | string[]>(
-    ext.id,
+    ext.uniqueId,
     name
   );
 
@@ -207,7 +210,7 @@ function MultiSelect({ ext, name, setting, disabled }: SettingsProps) {
           onChange: (value: string) => {
             if (disabled) return;
             MoonbaseSettingsStore.setExtensionConfig(
-              ext.id,
+              ext.uniqueId,
               name,
               Array.from(value)
             );
@@ -249,13 +252,13 @@ function RemoveEntryButton({
 function List({ ext, name, setting, disabled }: SettingsProps) {
   const { FormItem, FormText, TextInput, Button, Flex } = CommonComponents;
   const { value, displayName, description } = useConfigEntry<string[]>(
-    ext.id,
+    ext.uniqueId,
     name
   );
 
   const entries = value ?? [];
   const updateConfig = () =>
-    MoonbaseSettingsStore.setExtensionConfig(ext.id, name, entries);
+    MoonbaseSettingsStore.setExtensionConfig(ext.uniqueId, name, entries);
 
   return (
     <FormItem className={Margins.marginTop20} title={displayName}>
@@ -316,12 +319,12 @@ function Dictionary({ ext, name, setting, disabled }: SettingsProps) {
   const { FormItem, FormText, TextInput, Button, Flex } = CommonComponents;
   const { value, displayName, description } = useConfigEntry<
     Record<string, string>
-  >(ext.id, name);
+  >(ext.uniqueId, name);
 
   const entries = Object.entries(value ?? {});
   const updateConfig = () =>
     MoonbaseSettingsStore.setExtensionConfig(
-      ext.id,
+      ext.uniqueId,
       name,
       Object.fromEntries(entries)
     );


### PR DESCRIPTION
moonbase previously used the extension ID to differentiate between extensions. This worked well until two extensions used the same ID on different repositories. To fix this, every extension is assigned an auto-incrementing "unique ID" and is indexed and accessed by that ID. When an extension with the same extension ID but different unique ID is installed, the installation buttons are disabled.

I haven't tested updating an extension yet. I believe two extensions on the same repository will cause problems (as repository URL is used for differentiating sometimes) but I believe that to be considered an invalid repository.