### PR TITLE
contextMenu: Much more robust closing detection

### DIFF
--- a/packages/core-extensions/src/contextMenu/index.tsx
+++ b/packages/core-extensions/src/contextMenu/index.tsx
@@ -18,7 +18,7 @@ export const patches: Patch[] = [
       {
         match: /(?<=let\{[^}]+?\}=.;return ).\({[^}]+?}\)/,
         replacement: (render) =>
-          `require("contextMenu_contextMenu")._saveProps(${render})`
+          `require("contextMenu_contextMenu")._saveProps(this,${render})`
       }
     ]
   }

--- a/packages/core-extensions/src/contextMenu/webpackModules/contextMenu.ts
+++ b/packages/core-extensions/src/contextMenu/webpackModules/contextMenu.ts
@@ -43,11 +43,11 @@ function _patchMenu(props: MenuProps, items: InternalItem[]) {
 }
 
 let menuProps: any;
-function _saveProps(el: any) {
+function _saveProps(self: any, el: any) {
   menuProps = el.props;
 
-  const original = el.props.config.onClose;
-  el.props.config.onClose = function (...args: any[]) {
+  const original = self.props.closeContextMenu;
+  self.props.closeContextMenu = function (...args: any[]) {
     menuProps = undefined;
     return original?.apply(this, args);
   };


### PR DESCRIPTION
The previously patched function may not exist for some context menu element types, this one is guaranteed to exist.