### PR TITLE
core-ext/contextMenu: revert fixed patches

### DIFF
--- a/packages/core-extensions/src/contextMenu/index.tsx
+++ b/packages/core-extensions/src/contextMenu/index.tsx
@@ -5,7 +5,8 @@ export const patches: Patch[] = [
     find: "Menu API only allows Items and groups of Items as children.",
     replace: [
       {
-        match: /(?<=let{navId[^}]+?}=(.),(.)=.\(.\))/,
+        match:
+          /(?<=let{navId[^}]+?}=(.),(.)=function .\(.\){.+(?=,.=function))/,
         replacement: (_, props, items) =>
           `,__contextMenu=!${props}.__contextMenu_evilMenu&&require("contextMenu_contextMenu")._patchMenu(${props}, ${items})`
       }

--- a/packages/core-extensions/src/contextMenu/webpackModules/evilMenu.ts
+++ b/packages/core-extensions/src/contextMenu/webpackModules/evilMenu.ts
@@ -6,10 +6,8 @@ let code =
       "Menu API only allows Items and groups of Items as children."
     )[0].id
   ].toString();
-code = code.replace(
-  /onSelect:(.)}=(.),.=(.\(.\)),/,
-  `onSelect:$1}=$2;return $3;let `
-);
+code = code.replace(/,.=(?=function .\(.\){.+?,.=function)/, ";return ");
+code = code.replace(/,(?=__contextMenu)/, ";let ");
 const mod = new Function(
   "module",
   "exports",
@@ -18,7 +16,10 @@ const mod = new Function(
 );
 const exp: any = {};
 mod({}, exp, require);
-const Menu = spacepack.findFunctionByStrings(exp, "isUsingKeyboardNavigation")!;
+const Menu = spacepack.findFunctionByStrings(
+  exp,
+  "Menu API only allows Items and groups of Items as children."
+)!;
 module.exports = (el: any) => {
   return Menu({
     children: el,


### PR DESCRIPTION
This reverts the patches from commit b73b2d7ceb97bc9cce88e5395fefa2608635b08f,
whatever warranted that commit has been reverted and is now broken on both
stable and canary.
