### PR TITLE
Fix the last of the broken patches

### DIFF
--- a/packages/core-extensions/src/disableSentry/index.ts
+++ b/packages/core-extensions/src/disableSentry/index.ts
@@ -11,12 +11,11 @@ export const patches: Patch[] = [
     }
   },
   {
-    find: "window.DiscordSentry.addBreadcrumb",
+    find: "this._sentryUtils=",
     replace: {
       type: PatchReplaceType.Normal,
-      match: /Z:function\(\){return .}/,
-      replacement:
-        'default:function(){return (...args)=>{moonlight.getLogger("disableSentry").debug("Sentry calling addBreadcrumb passthrough:", ...args);}}'
+      match: /(?<=this._sentryUtils=)./,
+      replacement: "undefined"
     }
   },
   {

--- a/packages/core-extensions/src/quietLoggers/index.ts
+++ b/packages/core-extensions/src/quietLoggers/index.ts
@@ -8,10 +8,10 @@ const notXssDefensesOnly = () =>
 // that end up causing syntax errors by the normal patch
 const loggerFixes: Patch[] = [
   {
-    find: '"./ggsans-800-extrabolditalic.woff2":',
+    find: '"./gg-sans/ggsans-800-extrabolditalic.woff2":',
     replace: {
-      match: /throw .+?,./,
-      replacement: "return{}"
+      match: /var .=Error.+?;throw .+?,./,
+      replacement: ""
     }
   },
   {


### PR DESCRIPTION
- **core-ext/quietLoggers: fix remaining patch**
- **core-ext/disableSentry: patch out call of addBreadcrumbs that bypasses the stub**
