### PR TITLE
Fix moonbase card duplication issue

### DIFF
--- a/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/index.tsx
+++ b/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/index.tsx
@@ -96,7 +96,7 @@ export default function ExtensionsPage() {
         setSelectedTags={setSelectedTags}
       />
       {filtered.map((ext) => (
-        <ExtensionCard uniqueId={ext.uniqueId} key={ext.id} />
+        <ExtensionCard uniqueId={ext.uniqueId} key={ext.uniqueId} />
       ))}
     </>
   );


### PR DESCRIPTION
While we switched over to unique IDs for everything extension related in order to circumvent issues with local and remote extensions, the list key was not updated accordingly, resulting in ghost cards.
