### PR TITLE
persist: re-sign mac app bundle

### DIFF
--- a/packages/core/src/darwin.ts
+++ b/packages/core/src/darwin.ts
@@ -1,0 +1,96 @@
+import { spawn } from "node:child_process";
+import Logger from "./util/logger";
+
+/** Flags that may be passed to `codesign(1)` regardless of action. */
+export interface SharedCodesignOptions {
+  verbosityLevel?: number;
+}
+
+/** Flags that may be passed to `codesign(1)` when signing a bundle. */
+export interface SigningOptions extends SharedCodesignOptions {
+  /**
+   * Sign nested code items (such as Helper (Renderer).app, Helper (GPU).app, etc.)
+   *
+   * `--deep` is technically Bad (https://forums.developer.apple.com/forums/thread/129980),
+   * but it works for now.
+   */
+  deep?: boolean;
+
+  /** Steamrolls any existing code signature present in the bundle. */
+  force?: boolean;
+
+  /**
+   * The name of the signing identity to use. Signing identities are automatically queried from the user's keychains.
+   *
+   * `-` specifies ad-hoc signing, which does not involve an identity at all
+   * and is used to sign exactly one instance of code.
+   */
+  identity: "-" | (string & {}); // "& {}" prevents TS from unifying the literal.
+}
+
+const logger = new Logger("core/darwin");
+
+async function invokeCodesign(commandLineOptions: string[]) {
+  logger.debug("Invoking codesign with args:", commandLineOptions);
+  const codesignChild = spawn("/usr/bin/codesign", commandLineOptions, { stdio: "pipe" });
+
+  codesignChild.on("spawn", () => {
+    logger.debug(`Spawned codesign (pid: ${codesignChild.pid})`);
+  });
+  codesignChild.stdout.on("data", (data) => {
+    logger.debug("codesign stdout:", data.toString());
+  });
+  codesignChild.stderr.on("data", (data) => {
+    logger.debug("codesign stderr:", data.toString());
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    codesignChild.on("exit", (code, signal) => {
+      if (signal == null && code === 0) {
+        logger.debug("codesign peacefully exited");
+        resolve();
+      } else {
+        const reason = code != null ? `code ${code}` : `signal ${signal}`;
+        reject(`codesign exited with ${reason}`);
+      }
+    });
+  });
+}
+
+function* generateSharedCommandLineOptions(options: SharedCodesignOptions): IterableIterator<string> {
+  if (options.verbosityLevel) yield "-" + "v".repeat(options.verbosityLevel);
+}
+
+export function sign(bundlePath: string, options: SigningOptions): Promise<void> {
+  // codesign -s <IDENTITY> [-v] [--deep] [--force] <PATH>
+  function* cliOptions(): IterableIterator<string> {
+    yield "-s";
+    yield options.identity;
+
+    yield* generateSharedCommandLineOptions(options);
+    if (options.deep) yield "--deep";
+    if (options.force) yield "--force";
+
+    yield bundlePath;
+  }
+
+  return invokeCodesign(Array.from(cliOptions()));
+}
+
+export function verify(bundlePath: string, options: SharedCodesignOptions = {}): Promise<boolean> {
+  // codesign --verify [-v] <PATH>
+  function* cliOptions(): IterableIterator<string> {
+    yield "--verify";
+    yield* generateSharedCommandLineOptions(options);
+    yield bundlePath;
+  }
+
+  return invokeCodesign(Array.from(cliOptions())).then(
+    () => true,
+
+    // we're conflating codesign(1) itself erroring and codesign(1)
+    // successfully returning that the bundle is invalid, because it'd exit in
+    // an error in either case, but that's probably OK
+    () => false
+  );
+}

--- a/packages/injector/src/index.ts
+++ b/packages/injector/src/index.ts
@@ -268,7 +268,7 @@ export async function inject(asarPath: string) {
   if (isMoonlightDesktop) return;
 
   if (!hasOpenAsar && !isMoonlightDesktop) {
-    persist(asarPath);
+    await persist(asarPath);
   }
 
   // Need to do this instead of require() or it breaks require.main


### PR DESCRIPTION
This patch aims to implement proper persistence on Darwin (macOS) by reapplying the injector when an update finishes. It also forcibly signs the bundle to ensure that it has a stable [Designated Requirement](https://developer.apple.com/documentation/technotes/tn3127-inside-code-signing-requirements#Designated-requirement), which is important for e.g. screen sharing and keybinds to work consistently.

This doesn't work at the moment because it introduces some kind of race against the app becoming ready:

```
[INFO] [core/extension/loader] Loaded 10 extensions
[DEBUG] [core/persist] Inferred bundle path: /Applications/Discord.app
[DEBUG] [core/darwin] Invoking codesign with args: [ '--verify', '-vvv', '/Applications/Discord.app' ]
[DEBUG] [core/darwin] Spawned codesign (pid: 58755)
[DEBUG] [core/darwin] codesign stderr: --prepared:/Applications/Discord.app/Contents/Frameworks/Discord Helper (GPU).app
--validated:/Applications/Discord.app/Contents/Frameworks/Discord Helper (GPU).app
--prepared:/Applications/Discord.app/Contents/Frameworks/Discord Helper.app
--validated:/Applications/Discord.app/Contents/Frameworks/Discord Helper.app
--prepared:/Applications/Discord.app/Contents/Frameworks/ReactiveObjC.framework/Versions/Current/.
--validated:/Applications/Discord.app/Contents/Frameworks/ReactiveObjC.framework/Versions/Current/.
--prepared:/Applications/Discord.app/Contents/Frameworks/Mantle.framework/Versions/Current/.
--validated:/Applications/Discord.app/Contents/Frameworks/Mantle.framework/Versions/Current/.
--prepared:/Applications/Discord.app/Contents/Frameworks/Squirrel.framework/Versions/Current/.
--validated:/Applications/Discord.app/Contents/Frameworks/Squirrel.framework/Versions/Current/.
--prepared:/Applications/Discord.app/Contents/Frameworks/Discord Helper (Renderer).app
--validated:/Applications/Discord.app/Contents/Frameworks/Discord Helper (Renderer).app
--prepared:/Applications/Discord.app/Contents/Frameworks/Discord Helper (Plugin).app
--validated:/Applications/Discord.app/Contents/Frameworks/Discord Helper (Plugin).app
--prepared:/Applications/Discord.app/Contents/Frameworks/Electron Framework.framework/Versions/Current/.
--validated:/Applications/Discord.app/Contents/Frameworks/Electron Framework.framework/Versions/Current/.
/Applications/Discord.app: valid on disk
/Applications/Discord.app: satisfies its Designated Requirement

[DEBUG] [core/darwin] codesign peacefully exited
[WARN] [core/persist] Bundle is currently passing code signing, no need to sign
Discord 0.0.323
(node:58754) UnhandledPromiseRejectionWarning: Error: protocol.registerSchemesAsPrivileged should be called before app is ready
    at Object.beforeReadyProtocolRegistration (/Applications/Discord.app/Contents/Resources/_app.asar/app_bootstrap/protocols.js:10:22)
    at Object.<anonymous> (/Applications/Discord.app/Contents/Resources/_app.asar/app_bootstrap/bootstrap.js:213:20)
    at Module._compile (node:internal/modules/cjs/loader:1373:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1432:10)
    at Module.load (node:internal/modules/cjs/loader:1215:32)
    at Module._load (node:internal/modules/cjs/loader:1031:12)
    at c._load (node:electron/js2c/node_init:2:17025)
    at Module.require (node:internal/modules/cjs/loader:1240:19)
    at require (node:internal/modules/helpers:179:18)
    at Object.<anonymous> (/Applications/Discord.app/Contents/Resources/_app.asar/app_bootstrap/index.js:17:3)
    at emitUnhandledRejectionWarning (node:internal/process/promises:298:15)
    at warnWithErrorCodeUnhandledRejectionsMode (node:internal/process/promises:406:5)
    at processPromiseRejections (node:internal/process/promises:470:17)
    at process.processTicksAndRejections (node:internal/process/task_queues:96:32)
(node:58754) Error: protocol.registerSchemesAsPrivileged should be called before app is ready
    at Object.beforeReadyProtocolRegistration (/Applications/Discord.app/Contents/Resources/_app.asar/app_bootstrap/protocols.js:10:22)
    at Object.<anonymous> (/Applications/Discord.app/Contents/Resources/_app.asar/app_bootstrap/bootstrap.js:213:20)
    at Module._compile (node:internal/modules/cjs/loader:1373:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1432:10)
    at Module.load (node:internal/modules/cjs/loader:1215:32)
    at Module._load (node:internal/modules/cjs/loader:1031:12)
    at c._load (node:electron/js2c/node_init:2:17025)
    at Module.require (node:internal/modules/cjs/loader:1240:19)
    at require (node:internal/modules/helpers:179:18)
    at Object.<anonymous> (/Applications/Discord.app/Contents/Resources/_app.asar/app_bootstrap/index.js:17:3)
```

The code signing process succeeds, but by the time `registerSchemesAsPrivileged` runs (a function in Discord's ASAR) the app is already ready for some reason.

As I was repeatedly re-running this I managed to get past the error and get this one:

```
2024-12-15 17:15:33.521 Discord[59145:2331708] Download completed to: file:///Users/skip/Library/Caches/com.hnc.Discord.ShipIt/update.DX5Y9Kz/Discord.zip
2024-12-16T01:15:34.140Z [Modules] Host update failed: Error: Code signature at URL file:///Users/skip/Library/Caches/com.hnc.Discord.ShipIt/update.DX5Y9Kz/Discord.app/ did not pass validation: code failed to satisfy specified code requirement(s)
```

According to Squirrel, [the update bundle needs to match the DR of the target bundle](https://github.com/Squirrel/Squirrel.Mac/blob/0e5d146ba13101a1302d59ea6e6e0b3cace4ae38/Squirrel/SQRLInstaller.m#L64-L66), so we might need to actually sign the bundle in the installer too. Doing it from within core seems a bit precarious because macOS might not recognize the designated requirement changing on the fly like that.