### PR TITLE
Config API lifts

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -4,6 +4,7 @@ import Logger, { initLogger } from "@moonlight-mod/core/util/logger";
 import { getExtensions } from "@moonlight-mod/core/extension";
 import { loadExtensions } from "@moonlight-mod/core/extension/loader";
 import { MoonlightBranch, MoonlightNode } from "@moonlight-mod/types";
+import { getConfig, getConfigOption, getManifest, setConfigOption } from "@moonlight-mod/core/util/config";
 import { IndexedDB } from "@zenfs/dom";
 import { configure } from "@zenfs/core";
 import * as fs from "@zenfs/core/promises";
@@ -96,20 +97,16 @@ window._moonlightBrowserInit = async () => {
   };
 
   // Actual loading begins here
-  const config = await readConfig();
+  let config = await readConfig();
   initLogger(config);
 
   const extensions = await getExtensions();
   const processedExtensions = await loadExtensions(extensions);
 
-  function getConfig(ext: string) {
-    const val = config.extensions[ext];
-    if (val == null || typeof val === "boolean") return undefined;
-    return val.config;
-  }
-
   const moonlightNode: MoonlightNode = {
-    config,
+    get config() {
+      return config;
+    },
     extensions,
     processedExtensions,
     nativesCache: {},
@@ -118,14 +115,18 @@ window._moonlightBrowserInit = async () => {
     version: MOONLIGHT_VERSION,
     branch: MOONLIGHT_BRANCH as MoonlightBranch,
 
-    getConfig,
-    getConfigOption: <T>(ext: string, name: string) => {
-      const config = getConfig(ext);
-      if (config == null) return undefined;
-      const option = config[name];
-      if (option == null) return undefined;
-      return option as T;
+    getConfig(ext) {
+      return getConfig(ext, config);
     },
+    getConfigOption(ext, name) {
+      const manifest = getManifest(extensions, ext);
+      return getConfigOption(ext, name, config, manifest);
+    },
+    setConfigOption(ext, name, value) {
+      setConfigOption(config, ext, name, value);
+      this.writeConfig(config);
+    },
+
     getNatives: () => {},
     getLogger: (id: string) => {
       return new Logger(id);
@@ -138,7 +139,10 @@ window._moonlightBrowserInit = async () => {
       return `/extensions/${ext}`;
     },
 
-    writeConfig
+    async writeConfig(newConfig) {
+      await writeConfig(newConfig);
+      config = newConfig;
+    }
   };
 
   Object.assign(window, {

--- a/packages/core-extensions/src/moonbase/native.ts
+++ b/packages/core-extensions/src/moonbase/native.ts
@@ -178,15 +178,6 @@ export default function getNatives(): MoonbaseNatives {
     async deleteExtension(id) {
       const dir = moonlightNode.getExtensionDir(id);
       await moonlightNodeSandboxed.fs.rmdir(dir);
-    },
-
-    getExtensionConfig(id, key) {
-      const config = moonlightNode.config.extensions[id];
-      if (typeof config === "object") {
-        return config.config?.[key];
-      }
-
-      return undefined;
     }
   };
 }

--- a/packages/core-extensions/src/moonbase/types.ts
+++ b/packages/core-extensions/src/moonbase/types.ts
@@ -8,7 +8,6 @@ export type MoonbaseNatives = {
   fetchRepositories(repos: string[]): Promise<Record<string, RepositoryManifest[]>>;
   installExtension(manifest: RepositoryManifest, url: string, repo: string): Promise<void>;
   deleteExtension(id: string): Promise<void>;
-  getExtensionConfig(id: string, key: string): any;
 };
 
 export type RepositoryManifest = ExtensionManifest & {

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -1,0 +1,39 @@
+import type { Config, DetectedExtension, ExtensionManifest } from "@moonlight-mod/types";
+
+export function getManifest(extensions: DetectedExtension[], ext: string) {
+  return extensions.find((x) => x.id === ext)?.manifest;
+}
+
+export function getConfig(ext: string, config: Config) {
+  const val = config.extensions[ext];
+  if (val == null || typeof val === "boolean") return undefined;
+  return val.config;
+}
+
+export function getConfigOption<T>(
+  ext: string,
+  key: string,
+  config: Config,
+  manifest?: ExtensionManifest
+): T | undefined {
+  const defaultValue: T | undefined = structuredClone(manifest?.settings?.[key]?.default);
+  const cfg = getConfig(ext, config);
+  if (cfg == null || typeof cfg === "boolean") return defaultValue;
+  return cfg?.[key] ?? defaultValue;
+}
+
+export function setConfigOption<T>(config: Config, ext: string, key: string, value: T) {
+  const oldConfig = config.extensions[ext];
+  const newConfig =
+    typeof oldConfig === "boolean"
+      ? {
+          enabled: oldConfig,
+          config: { [key]: value }
+        }
+      : {
+          ...oldConfig,
+          config: { ...(oldConfig?.config ?? {}), [key]: value }
+        };
+
+  config.extensions[ext] = newConfig;
+}

--- a/packages/types/src/globals.ts
+++ b/packages/types/src/globals.ts
@@ -34,6 +34,8 @@ export type MoonlightNode = {
 
   getConfig: (ext: string) => ConfigExtension["config"];
   getConfigOption: <T>(ext: string, name: string) => T | undefined;
+  setConfigOption: <T>(ext: string, name: string, value: T) => void;
+
   getNatives: (ext: string) => any | undefined;
   getLogger: (id: string) => Logger;
 
@@ -63,8 +65,11 @@ export type MoonlightWeb = {
   version: string;
   branch: MoonlightBranch;
 
-  getConfig: (ext: string) => ConfigExtension["config"];
-  getConfigOption: <T>(ext: string, name: string) => T | undefined;
+  // Re-exports for ease of use
+  getConfig: MoonlightNode["getConfig"];
+  getConfigOption: MoonlightNode["getConfigOption"];
+  setConfigOption: MoonlightNode["setConfigOption"];
+
   getNatives: (ext: string) => any | undefined;
   getLogger: (id: string) => Logger;
   lunast: LunAST;

--- a/packages/web-preload/src/index.ts
+++ b/packages/web-preload/src/index.ts
@@ -30,6 +30,8 @@ async function load() {
 
     getConfig: moonlightNode.getConfig.bind(moonlightNode),
     getConfigOption: moonlightNode.getConfigOption.bind(moonlightNode),
+    setConfigOption: moonlightNode.setConfigOption.bind(moonlightNode),
+
     getNatives: moonlightNode.getNatives.bind(moonlightNode),
     getLogger(id) {
       return new Logger(id);


### PR DESCRIPTION
Closes #136.

- Shared config logic between browser, node-preload, and Moonbase. These were duplicated around everywhere so I made a new util file for it. It's not in the original config file because of tree shaking.
- Made the config a getter so we can write to it and have it update in real time.
- Extensions can write to their own config. Writing to a config saves it instantly. This *will* conflict with Moonbase's logic, but given that an extension would write to their own config from e.g. a UI action, I don't think this is a huge deal (you'd always be in the Moonbase UI when editing the Moonbase config).