### PR TITLE
Patch improvements

### DIFF
--- a/packages/core/src/extension/loader.ts
+++ b/packages/core/src/extension/loader.ts
@@ -60,18 +60,11 @@ async function loadExtWeb(ext: DetectedExtension) {
       let idx = 0;
       for (const patch of exports.patches) {
         if (Array.isArray(patch.replace)) {
-          for (const replacement of patch.replace) {
-            const newPatch = Object.assign({}, patch, {
-              replace: replacement
-            });
-
-            registerPatch({ ...newPatch, ext: ext.id, id: idx });
-            idx++;
-          }
-        } else {
           registerPatch({ ...patch, ext: ext.id, id: idx });
-          idx++;
+        } else {
+          registerPatch({ ...patch, replace: [patch.replace], ext: ext.id, id: idx });
         }
+        idx++;
       }
     }
 

--- a/packages/types/src/extension.ts
+++ b/packages/types/src/extension.ts
@@ -108,6 +108,7 @@ export type PatchReplace =
 export type Patch = {
   find: PatchMatch;
   replace: PatchReplace | PatchReplace[];
+  hardFail?: boolean; // if any patches fail, all fail
   prerequisite?: () => boolean;
 };
 


### PR DESCRIPTION
Closes #116, #117, #148, #149. (lol)

- Patches are now represented internally as an array, always. Previously this was inverted behavior where we spread arrays into multiple separate patches.
- `find` is matched against the original module string. Extensions cannot use other extensions' changes to find modules.
- `find` should be able to take a mapped module name as input.
- Some reworking on how patches are applied to hopefully be less buggy.
- Introduced `hardFail` which acts as patch grouping, by patching a temporary variable and then only assigning it if it didn't hard fail.

Most of this is untested, so I'd like some help with that.