### PR TITLE
Entrypoint cleanup

### DIFF
--- a/packages/core-extensions/src/disableSentry/node.ts
+++ b/packages/core-extensions/src/disableSentry/node.ts
@@ -5,19 +5,17 @@ import { constants } from "@moonlight-mod/types";
 
 const logger = moonlightNode.getLogger("disableSentry");
 
-if (!ipcRenderer.sendSync(constants.ipcGetIsMoonlightDesktop)) {
-  const preloadPath = ipcRenderer.sendSync(constants.ipcGetOldPreloadPath);
-  try {
-    const sentryPath = require.resolve(resolve(preloadPath, "..", "node_modules", "@sentry", "electron"));
-    require.cache[sentryPath] = new Module(sentryPath, require.cache[require.resolve(preloadPath)]);
-    require.cache[sentryPath]!.exports = {
-      init: () => {},
-      setTag: () => {},
-      setUser: () => {},
-      captureMessage: () => {}
-    };
-    logger.debug("Stubbed Sentry node side!");
-  } catch (err) {
-    logger.error("Failed to stub Sentry:", err);
-  }
+const preloadPath = ipcRenderer.sendSync(constants.ipcGetOldPreloadPath);
+try {
+  const sentryPath = require.resolve(resolve(preloadPath, "..", "node_modules", "@sentry", "electron"));
+  require.cache[sentryPath] = new Module(sentryPath, require.cache[require.resolve(preloadPath)]);
+  require.cache[sentryPath]!.exports = {
+    init: () => {},
+    setTag: () => {},
+    setUser: () => {},
+    captureMessage: () => {}
+  };
+  logger.debug("Stubbed Sentry node side!");
+} catch (err) {
+  logger.error("Failed to stub Sentry:", err);
 }

--- a/packages/node-preload/src/index.ts
+++ b/packages/node-preload/src/index.ts
@@ -66,21 +66,20 @@ async function injectGlobals() {
       setConfigOption(config, ext, name, value);
       this.writeConfig(config);
     },
+    async writeConfig(newConfig) {
+      await writeConfig(newConfig);
+      config = newConfig;
+    },
 
     getNatives: (ext: string) => global.moonlightNode.nativesCache[ext],
     getLogger: (id: string) => {
       return new Logger(id);
     },
-
     getMoonlightDir() {
       return moonlightDir;
     },
     getExtensionDir: (ext: string) => {
       return path.join(extensionsPath, ext);
-    },
-    async writeConfig(newConfig) {
-      await writeConfig(newConfig);
-      config = newConfig;
     }
   };
 

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -8,7 +8,7 @@ export const ipcNodePreloadKickoff = "_moonlight_nodePreloadKickoff";
 export const ipcGetOldPreloadPath = "_moonlight_getOldPreloadPath";
 
 export const ipcGetAppData = "_moonlight_getAppData";
-export const ipcGetIsMoonlightDesktop = "_moonlight_getIsMoonlightDesktop";
+export const ipcGetInjectorConfig = "_moonlight_getInjectorConfig";
 export const ipcMessageBox = "_moonlight_messageBox";
 export const ipcSetCorsList = "_moonlight_setCorsList";
 export const ipcSetBlockedList = "_moonlight_setBlockedList";

--- a/packages/types/src/globals.ts
+++ b/packages/types/src/globals.ts
@@ -8,18 +8,23 @@ import type { EventPayloads, EventType, MoonlightEventEmitter } from "./core/eve
 import { MoonlightFS } from "./fs";
 
 export type MoonlightHost = {
-  asarPath: string;
   config: Config;
-  events: EventEmitter;
   extensions: DetectedExtension[];
   processedExtensions: ProcessedExtensions;
+  asarPath: string;
+  events: EventEmitter;
 
   version: string;
   branch: MoonlightBranch;
 
   getConfig: (ext: string) => ConfigExtension["config"];
   getConfigOption: <T>(ext: string, name: string) => T | undefined;
+  setConfigOption: <T>(ext: string, name: string, value: T) => void;
+  writeConfig: (config: Config) => Promise<void>;
+
   getLogger: (id: string) => Logger;
+  getMoonlightDir: () => string;
+  getExtensionDir: (ext: string) => string;
 };
 
 export type MoonlightNode = {
@@ -35,13 +40,12 @@ export type MoonlightNode = {
   getConfig: (ext: string) => ConfigExtension["config"];
   getConfigOption: <T>(ext: string, name: string) => T | undefined;
   setConfigOption: <T>(ext: string, name: string, value: T) => void;
+  writeConfig: (config: Config) => Promise<void>;
 
   getNatives: (ext: string) => any | undefined;
   getLogger: (id: string) => Logger;
-
   getMoonlightDir: () => string;
   getExtensionDir: (ext: string) => string;
-  writeConfig: (config: Config) => Promise<void>;
 };
 
 export type MoonlightNodeSandboxed = {
@@ -54,7 +58,6 @@ export type MoonlightWeb = {
   unpatched: Set<IdentifiedPatch>;
   pendingModules: Set<IdentifiedWebpackModule>;
   enabledExtensions: Set<string>;
-  apiLevel: number;
   events: MoonlightEventEmitter<EventType, EventPayloads>;
   patchingInternals: {
     onModuleLoad: (moduleId: string | string[], callback: (moduleId: string) => void) => void;
@@ -65,14 +68,17 @@ export type MoonlightWeb = {
 
   version: string;
   branch: MoonlightBranch;
+  apiLevel: number;
 
   // Re-exports for ease of use
   getConfig: MoonlightNode["getConfig"];
   getConfigOption: MoonlightNode["getConfigOption"];
   setConfigOption: MoonlightNode["setConfigOption"];
+  writeConfig: MoonlightNode["writeConfig"];
 
   getNatives: (ext: string) => any | undefined;
   getLogger: (id: string) => Logger;
+
   lunast: LunAST;
   moonmap: Moonmap;
 };

--- a/packages/web-preload/src/index.ts
+++ b/packages/web-preload/src/index.ts
@@ -15,10 +15,10 @@ async function load() {
   const logger = new Logger("web-preload");
 
   window.moonlight = {
-    apiLevel: constants.apiLevel,
     unpatched: new Set(),
     pendingModules: new Set(),
     enabledExtensions: new Set(),
+
     events: createEventEmitter<EventType, EventPayloads>(),
     patchingInternals: {
       onModuleLoad,
@@ -29,15 +29,18 @@ async function load() {
 
     version: MOONLIGHT_VERSION,
     branch: MOONLIGHT_BRANCH as MoonlightBranch,
+    apiLevel: constants.apiLevel,
 
     getConfig: moonlightNode.getConfig.bind(moonlightNode),
     getConfigOption: moonlightNode.getConfigOption.bind(moonlightNode),
     setConfigOption: moonlightNode.setConfigOption.bind(moonlightNode),
+    writeConfig: moonlightNode.writeConfig.bind(moonlightNode),
 
     getNatives: moonlightNode.getNatives.bind(moonlightNode),
     getLogger(id) {
       return new Logger(id);
     },
+
     lunast: new LunAST(),
     moonmap: new Moonmap()
   };


### PR DESCRIPTION
- Removes OpenAsar-specific hacks. This was half baked and nobody used this to my knowledge.
  - Would likely be better off implemented with an extension - if someone's interested in making this, we can add the events required to implement it if any.
- Removed potential desktop scaffolding - we 100% aren't making this and nobody else seems to be, so I don't see the point keeping it around.
- To ensure that the last two points being removed don't cause issues, introduced a new optional config to the injector, with an IPC call to fetch it Node side if required.
- Ensured all the globals can do more or less the same thing. Some (especially host) were missing a lot of functionality.
- Sorted all the fields in the globals because I have some sort of mental disorder that commands my brain to make it look nice.