### PR TITLE
moonbase: don't set `hasUpdate` to false after installing an extension

### DIFF
--- a/packages/core-extensions/src/moonbase/webpackModules/stores.ts
+++ b/packages/core-extensions/src/moonbase/webpackModules/stores.ts
@@ -274,7 +274,6 @@ class MoonbaseSettingsStore extends Store<any> {
         existing.settingsOverride = update.updateManifest.settings;
         existing.compat = checkExtensionCompat(update.updateManifest);
         existing.manifest = update.updateManifest;
-        existing.hasUpdate = false;
         existing.changelog = update.updateManifest.meta?.changelog;
       }
 
@@ -403,7 +402,6 @@ class MoonbaseSettingsStore extends Store<any> {
       // If it's enabled but not detected yet, restart.
       if (newEnabled && !detected) {
         return updateAdvice(RestartAdvice.RestartNeeded);
-        continue;
       }
 
       // Toggling extensions specifically wants to rely on the initial state,


### PR DESCRIPTION
so extensions that just updated stay pinned at the top of the extensions list