### PR TITLE
Silence bracket-style logs and highlight.js logs

### DIFF
--- a/packages/core-extensions/src/quietLoggers/index.ts
+++ b/packages/core-extensions/src/quietLoggers/index.ts
@@ -58,6 +58,24 @@ export const patches: Patch[] = [
       replacement: "(true)"
     }
   },
+  // The various [bracket style] logs
+  {
+    find: "Σ:",
+    replace: {
+      match: "for",
+      replacement: "return;for"
+    },
+    prerequisite: notXssDefensesOnly
+  },
+  // Highlight.js deprecation warnings
+  {
+    find: "Deprecated as of",
+    replace: {
+      match: /console\./g,
+      replacement: "false&&console."
+    },
+    prerequisite: notXssDefensesOnly
+  },
   ...loggerFixes,
   ...stubPatches.map((patch) => ({
     find: patch[0],

--- a/packages/core-extensions/src/quietLoggers/index.ts
+++ b/packages/core-extensions/src/quietLoggers/index.ts
@@ -3,6 +3,8 @@ import { Patch } from "@moonlight-mod/types";
 const notXssDefensesOnly = () =>
   (moonlight.getConfigOption<boolean>("quietLoggers", "xssDefensesOnly") ?? false) === false;
 
+const silenceDiscordLogger = moonlight.getConfigOption<boolean>("quietLoggers", "silenceDiscordLogger") ?? false;
+
 // These patches MUST run before the simple patches, these are to remove loggers
 // that end up causing syntax errors by the normal patch
 const loggerFixes: Patch[] = [
@@ -58,15 +60,6 @@ export const patches: Patch[] = [
       replacement: "(true)"
     }
   },
-  // The various [bracket style] logs
-  {
-    find: "Σ:",
-    replace: {
-      match: "for",
-      replacement: "return;for"
-    },
-    prerequisite: notXssDefensesOnly
-  },
   // Highlight.js deprecation warnings
   {
     find: "Deprecated as of",
@@ -75,6 +68,15 @@ export const patches: Patch[] = [
       replacement: "false&&console."
     },
     prerequisite: notXssDefensesOnly
+  },
+  // Discord's logger
+  {
+    find: "Σ:",
+    replace: {
+      match: "for",
+      replacement: "return;for"
+    },
+    prerequisite: () => silenceDiscordLogger && notXssDefensesOnly()
   },
   ...loggerFixes,
   ...stubPatches.map((patch) => ({

--- a/packages/core-extensions/src/quietLoggers/manifest.json
+++ b/packages/core-extensions/src/quietLoggers/manifest.json
@@ -15,6 +15,13 @@
       "description": "Only disable self XSS prevention log",
       "type": "boolean",
       "default": false
+    },
+    "silenceDiscordLogger": {
+      "advice": "reload",
+      "displayName": "Silence Discord logger",
+      "description": "Hides all messages from Discord's logger (the logs that start with purple text in brackets)",
+      "type": "boolean",
+      "default": false
     }
   }
 }


### PR DESCRIPTION
Hides these logs:

<img width="413" alt="image" src="https://github.com/user-attachments/assets/33e64daf-1618-4bb1-b351-67ea9fa9d3df" />
