### PR TITLE
Remove `prefetch-src` from CSP patching

### DIFF
--- a/packages/injector/src/index.ts
+++ b/packages/injector/src/index.ts
@@ -77,16 +77,7 @@ ipcMain.handle(constants.ipcSetBlockedList, (_, list: string[]) => {
 });
 
 function patchCsp(headers: Record<string, string[]>) {
-  const directives = [
-    "script-src",
-    "style-src",
-    "connect-src",
-    "img-src",
-    "font-src",
-    "media-src",
-    "worker-src",
-    "prefetch-src"
-  ];
+  const directives = ["script-src", "style-src", "connect-src", "img-src", "font-src", "media-src", "worker-src"];
   const values = ["*", "blob:", "data:", "'unsafe-inline'", "'unsafe-eval'", "disclip:"];
 
   const csp = "content-security-policy";


### PR DESCRIPTION
`prefetch-src` is deprecated and causes errors to be thrown in the console when it's present (at least on desktop macOS).

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/prefetch-src