### PR TITLE
moonbase: various fixes

### DIFF
--- a/packages/core-extensions/src/moonbase/webpackModules/stores.ts
+++ b/packages/core-extensions/src/moonbase/webpackModules/stores.ts
@@ -28,15 +28,6 @@ class MoonbaseSettingsStore extends Store<any> {
   newVersion: string | null;
   shouldShowNotice: boolean;
 
-  #showOnlyUpdateable = false;
-  set showOnlyUpdateable(v: boolean) {
-    this.#showOnlyUpdateable = v;
-    this.emitChange();
-  }
-  get showOnlyUpdateable() {
-    return this.#showOnlyUpdateable;
-  }
-
   restartAdvice = RestartAdvice.NotNeeded;
 
   extensions: { [id: number]: MoonbaseExtension };
@@ -251,6 +242,13 @@ class MoonbaseSettingsStore extends Store<any> {
 
     this.config.extensions[ext.id] = val;
     this.modified = this.isModified();
+    this.emitChange();
+  }
+
+  dismissAllExtensionUpdates() {
+    for (const id in this.extensions) {
+      this.extensions[id].hasUpdate = false;
+    }
     this.emitChange();
   }
 

--- a/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/card.tsx
+++ b/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/card.tsx
@@ -255,41 +255,37 @@ export default function ExtensionCard({ uniqueId }: { uniqueId: number }) {
                 padding: "0 20px"
               }}
             >
-              <Flex direction={Flex.Direction.HORIZONTAL}>
-                <TabBar.Item className={TabBarClasses.tabBarItem} id={ExtensionPage.Info}>
-                  Info
+              <TabBar.Item className={TabBarClasses.tabBarItem} id={ExtensionPage.Info}>
+                Info
+              </TabBar.Item>
+
+              {description != null && (
+                <TabBar.Item className={TabBarClasses.tabBarItem} id={ExtensionPage.Description}>
+                  Description
                 </TabBar.Item>
+              )}
 
-                {description != null && (
-                  <TabBar.Item className={TabBarClasses.tabBarItem} id={ExtensionPage.Description}>
-                    Description
-                  </TabBar.Item>
-                )}
-
-                {changelog != null && (
-                  <TabBar.Item className={TabBarClasses.tabBarItem} id={ExtensionPage.Changelog}>
-                    Changelog
-                  </TabBar.Item>
-                )}
-                {settings != null && (
-                  <TabBar.Item className={TabBarClasses.tabBarItem} id={ExtensionPage.Settings}>
-                    Settings
-                  </TabBar.Item>
-                )}
-              </Flex>
+              {changelog != null && (
+                <TabBar.Item className={TabBarClasses.tabBarItem} id={ExtensionPage.Changelog}>
+                  Changelog
+                </TabBar.Item>
+              )}
+              {settings != null && (
+                <TabBar.Item className={TabBarClasses.tabBarItem} id={ExtensionPage.Settings}>
+                  Settings
+                </TabBar.Item>
+              )}
             </TabBar>
 
-            {linkButtons.length > 0 && (
-              <Flex
-                align={Flex.Align.CENTER}
-                justify={Flex.Justify.END}
-                direction={Flex.Direction.HORIZONTAL}
-                grow={1}
-                className="moonbase-link-buttons"
-              >
-                {linkButtons}
-              </Flex>
-            )}
+            <Flex
+              align={Flex.Align.CENTER}
+              justify={Flex.Justify.END}
+              direction={Flex.Direction.HORIZONTAL}
+              grow={1}
+              className="moonbase-link-buttons"
+            >
+              {linkButtons.length > 0 && linkButtons}
+            </Flex>
           </Flex>
         )}
 

--- a/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/index.tsx
+++ b/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/index.tsx
@@ -17,11 +17,10 @@ const { FormDivider, CircleInformationIcon, XSmallIcon, Button } = Components;
 const PanelButton = spacepack.findByCode("Masks.PANEL_BUTTON")[0].exports.Z;
 
 export default function ExtensionsPage() {
-  const { extensions, savedFilter, showOnlyUpdateable } = useStateFromStoresObject([MoonbaseSettingsStore], () => {
+  const { extensions, savedFilter } = useStateFromStoresObject([MoonbaseSettingsStore], () => {
     return {
       extensions: MoonbaseSettingsStore.extensions,
-      savedFilter: MoonbaseSettingsStore.getExtensionConfigRaw<number>("moonbase", "filter", defaultFilter),
-      showOnlyUpdateable: MoonbaseSettingsStore.showOnlyUpdateable
+      savedFilter: MoonbaseSettingsStore.getExtensionConfigRaw<number>("moonbase", "filter", defaultFilter)
     };
   });
 
@@ -78,8 +77,7 @@ export default function ExtensionsPage() {
 
   // Prioritize extensions with updates
   const filteredWithUpdates = filtered.filter((ext) => ext!.hasUpdate);
-  const filterUpdates = showOnlyUpdateable && filteredWithUpdates.length > 0;
-  const filteredWithoutUpdates = filterUpdates ? [] : filtered.filter((ext) => !ext!.hasUpdate);
+  const filteredWithoutUpdates = filtered.filter((ext) => !ext!.hasUpdate);
 
   return (
     <>
@@ -98,22 +96,20 @@ export default function ExtensionsPage() {
       />
       <FilterBar filter={filter} setFilter={setFilter} selectedTags={selectedTags} setSelectedTags={setSelectedTags} />
 
-      {filterUpdates && (
+      {filteredWithUpdates.length > 0 && (
         <HelpMessage
           icon={CircleInformationIcon}
-          text="Only displaying updates"
+          text="Extension updates are available"
           className="moonbase-extension-update-section"
         >
           <div className="moonbase-help-message-buttons">
             <Button
-              look={Button.Looks.OUTLINED}
-              color={Button.Colors.PRIMARY}
+              color={Button.Colors.BRAND}
               size={Button.Sizes.TINY}
               disabled={hitUpdateAll}
               onClick={() => {
                 setHitUpdateAll(true);
                 MoonbaseSettingsStore.updateAllExtensions();
-                MoonbaseSettingsStore.showOnlyUpdateable = false;
               }}
             >
               Update all
@@ -121,7 +117,7 @@ export default function ExtensionsPage() {
             <PanelButton
               icon={XSmallIcon}
               onClick={() => {
-                MoonbaseSettingsStore.showOnlyUpdateable = false;
+                MoonbaseSettingsStore.dismissAllExtensionUpdates();
               }}
             />
           </div>

--- a/packages/core-extensions/src/moonbase/webpackModules/ui/index.tsx
+++ b/packages/core-extensions/src/moonbase/webpackModules/ui/index.tsx
@@ -8,7 +8,6 @@ import ExtensionsPage from "./extensions";
 import ConfigPage from "./config";
 import AboutPage from "./about";
 import Update from "./update";
-import { MoonbaseSettingsStore } from "@moonlight-mod/wp/moonbase_stores";
 import RestartAdviceMessage from "./RestartAdvice";
 
 const { Divider } = spacepack.findByCode(".forumOrHome]:")[0].exports.Z;
@@ -52,7 +51,6 @@ export function Moonbase(props: { initialTab?: number } = {}) {
     () => () => {
       // Normally there's an onSettingsClose prop you can set but we don't expose it and I don't care enough to add support for it right now
       clearSubsection("moonbase");
-      MoonbaseSettingsStore.showOnlyUpdateable = false;
     },
     []
   );

--- a/packages/core-extensions/src/moonbase/webpackModules/updates.tsx
+++ b/packages/core-extensions/src/moonbase/webpackModules/updates.tsx
@@ -63,7 +63,6 @@ function listener() {
             if (MoonbaseSettingsStore.getExtensionConfigRaw<boolean>("moonbase", "sections", false)) {
               open("moonbase-extensions");
             } else {
-              MoonbaseSettingsStore.showOnlyUpdateable = true;
               open("moonbase", 0);
             }
             return true;


### PR DESCRIPTION
This revamps Moonbase update handling a bit, dismissing the update notice now gets
rid of extensions that have updates, it is shown by default and extensions stay
after updating all of them.

Additionally, tab bar functionality is fixed after #173.
