### PR TITLE
moonbase: Fix restart advice getting stuck when changing option for the first time

### DIFF
--- a/packages/core-extensions/src/moonbase/webpackModules/stores.ts
+++ b/packages/core-extensions/src/moonbase/webpackModules/stores.ts
@@ -437,11 +437,18 @@ class MoonbaseSettingsStore extends Store<any> {
         }
       }
 
-      const initConfig = typeof initState === "boolean" ? {} : initState?.config ?? {};
-      const newConfig = typeof newState === "boolean" ? {} : newState?.config ?? {};
+      const initConfig = typeof initState === "boolean" ? {} : { ...initState?.config };
+      const newConfig = typeof newState === "boolean" ? {} : { ...newState?.config };
 
       const def = ext.manifest.settings;
       if (!def) continue;
+
+      for (const key in def) {
+        const defaultValue = def[key].default;
+
+        if (initConfig[key] == null) Object.defineProperty(initConfig, key, { value: defaultValue, enumerable: true });
+        if (newConfig[key] == null) Object.defineProperty(newConfig, key, { value: defaultValue, enumerable: true });
+      }
 
       const changedKeys = diff(initConfig, newConfig, { cyclesFix: false }).map((c) => c.path[0]);
       for (const key in def) {

--- a/packages/core-extensions/src/moonbase/webpackModules/stores.ts
+++ b/packages/core-extensions/src/moonbase/webpackModules/stores.ts
@@ -446,8 +446,8 @@ class MoonbaseSettingsStore extends Store<any> {
       for (const key in def) {
         const defaultValue = def[key].default;
 
-        if (initConfig[key] == null) Object.defineProperty(initConfig, key, { value: defaultValue, enumerable: true });
-        if (newConfig[key] == null) Object.defineProperty(newConfig, key, { value: defaultValue, enumerable: true });
+        initConfig[key] ??= defaultValue;
+        newConfig[key] ??= defaultValue;
       }
 
       const changedKeys = diff(initConfig, newConfig, { cyclesFix: false }).map((c) => c.path[0]);


### PR DESCRIPTION
You can easily reproduce this by resetting the config file and enabling and disabling Add to global scope in Spacepack. The notice should disappear, but it doesn't.
Initially I was trying to fix #180 but it turns out that was already fixed and I was on the wrong branch :trollface: (I swear I read the docs I just kind of forgot)