### PR TITLE
moonbase: add back description tab

### DIFF
--- a/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/card.tsx
+++ b/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/card.tsx
@@ -256,6 +256,12 @@ export default function ExtensionCard({ uniqueId }: { uniqueId: number }) {
                 Info
               </TabBar.Item>
 
+              {description != null && (
+                <TabBar.Item className={DiscoveryClasses.tabBarItem} id={ExtensionPage.Description}>
+                  Description
+                </TabBar.Item>
+              )}
+
               {changelog != null && (
                 <TabBar.Item className={DiscoveryClasses.tabBarItem} id={ExtensionPage.Changelog}>
                   Changelog


### PR DESCRIPTION
The description tab was accidentally deleted in merge commit b7e5982a47db4db63443ac4b74c8f7b737d17cdd.
