### PR TITLE
Misc Moonbase stuff

### DIFF
--- a/packages/core-extensions/src/moonbase/webpackModules/stores.ts
+++ b/packages/core-extensions/src/moonbase/webpackModules/stores.ts
@@ -477,6 +477,7 @@ class MoonbaseSettingsStore extends Store<any> {
   writeConfig() {
     this.submitting = true;
     this.restartAdvice = this.#computeRestartAdvice();
+    const modifiedRepos = diff(this.savedConfig.repositories, this.config.repositories);
 
     moonlightNode.writeConfig(this.config);
     this.savedConfig = this.clone(this.config);
@@ -484,6 +485,8 @@ class MoonbaseSettingsStore extends Store<any> {
     this.submitting = false;
     this.modified = false;
     this.emitChange();
+
+    if (modifiedRepos) this.checkUpdates();
   }
 
   reset() {

--- a/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/card.tsx
+++ b/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/card.tsx
@@ -15,7 +15,8 @@ import {
   Button,
   ChannelListIcon,
   HeartIcon,
-  WindowTopOutlineIcon
+  WindowTopOutlineIcon,
+  WarningIcon
 } from "@moonlight-mod/wp/discord/components/common/index";
 import React from "@moonlight-mod/wp/react";
 import { useStateFromStores } from "@moonlight-mod/wp/discord/packages/flux";
@@ -124,6 +125,12 @@ export default function ExtensionCard({ uniqueId }: { uniqueId: number }) {
             {hasDuplicateEntry && ext?.source?.url && (
               <Tooltip text={`This extension is from the following repository: ${ext.source.url}`} position="top">
                 {(props: any) => <WindowTopOutlineIcon {...props} class={BuildOverrideClasses.infoIcon} size="xs" />}
+              </Tooltip>
+            )}
+
+            {ext.manifest?.meta?.deprecated && (
+              <Tooltip text="This extension is deprecated" position="top">
+                {(props: any) => <WarningIcon {...props} class={BuildOverrideClasses.infoIcon} size="xs" />}
               </Tooltip>
             )}
           </Flex>

--- a/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/filterBar.tsx
+++ b/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/filterBar.tsx
@@ -31,7 +31,8 @@ export enum Filter {
   Disabled = 1 << 4,
   Installed = 1 << 5,
   Repository = 1 << 6,
-  Incompatible = 1 << 7
+  Incompatible = 1 << 7,
+  Deprecated = 1 << 8
 }
 export const defaultFilter = 127 as Filter;
 
@@ -121,6 +122,12 @@ function FilterButtonPopout({
             label="Show incompatible"
             checked={(filter & Filter.Incompatible) === Filter.Incompatible}
             action={() => toggleFilter(Filter.Incompatible)}
+          />
+          <MenuCheckboxItem
+            id="l-deprecated"
+            label="Show deprecated"
+            checked={(filter & Filter.Deprecated) === Filter.Deprecated}
+            action={() => toggleFilter(Filter.Deprecated)}
           />
           <MenuItem
             id="reset-all"

--- a/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/index.tsx
+++ b/packages/core-extensions/src/moonbase/webpackModules/ui/extensions/index.tsx
@@ -76,7 +76,10 @@ export default function ExtensionsPage() {
       ) &&
       (filter & Filter.Incompatible ||
         ext.compat === ExtensionCompat.Compatible ||
-        (ext.compat === ExtensionCompat.InvalidApiLevel && ext.hasUpdate))
+        (ext.compat === ExtensionCompat.InvalidApiLevel && ext.hasUpdate)) &&
+      (filter & Filter.Deprecated ||
+        ext.manifest?.meta?.deprecated !== true ||
+        ext.state !== ExtensionState.NotDownloaded)
   );
 
   // Prioritize extensions with updates


### PR DESCRIPTION
Closes https://github.com/moonlight-mod/moonlight/issues/184, https://github.com/moonlight-mod/moonlight/issues/182.

- Repositories are diffed upon writing the config, and if so it'll re-fetch the updates (same action as clicking refresh in Moonbase). This only fetches new extensions (won't remove existing ones if you remove a repo), but good enough. (Also, it technically checks for an unneeded update to moonlight, but ehhh who cares)
- Deprecated extensions have a filter next to incompatible, defaulting to off. There's also a new warning badge now. Deprecated extensions that are installed (enabled or disabled) will bypass the filter. This will only hide extensions that are from a remote repository and haven't been installed yet - users will no longer see the extension when they uninstall it, which I think matches the expected behavior.

I would like to get https://github.com/moonlight-mod/moonlight/issues/183 done tomorrow, but the logic makes my brain hurt, so that's Kasi's job.