### PR TITLE
feat(settings): allow computed pos property for settings sections

### DIFF
--- a/packages/core-extensions/src/settings/webpackModules/settings.ts
+++ b/packages/core-extensions/src/settings/webpackModules/settings.ts
@@ -43,6 +43,10 @@ export const Settings: SettingsType = {
 
   _mutateSections: (sections) => {
     for (const section of Settings.ourSections) {
+      // Discord's `pos` only supports numbers, so lets call the function to get the position.
+      if (typeof section.pos === "function") {
+        section.pos = section.pos(sections);
+      }
       sections.splice(section.pos < 0 ? sections.length + section.pos : section.pos, 0, section);
     }
 

--- a/packages/types/src/coreExtensions/settings.ts
+++ b/packages/types/src/coreExtensions/settings.ts
@@ -7,14 +7,14 @@ export type NoticeProps = {
 };
 
 export type SettingsSection =
-  | { section: "DIVIDER"; pos: number }
-  | { section: "HEADER"; label: string; pos: number }
+  | { section: "DIVIDER"; pos: number | ((sections: SettingsSection[]) => number) }
+  | { section: "HEADER"; label: string; pos: number | ((sections: SettingsSection[]) => number) }
   | {
       section: string;
       label: string;
       color: string | null;
       element: React.FunctionComponent;
-      pos: number;
+      pos: number | ((sections: SettingsSection[]) => number);
       notice?: NoticeProps;
       _moonlight_submenu?: () => ReactElement | ReactElement[];
     };
@@ -38,7 +38,7 @@ export type Settings = {
     label: string,
     element: React.FunctionComponent,
     color?: string | null,
-    pos?: number,
+    pos?: number | ((section: unknown) => number),
     notice?: NoticeProps
   ) => void;
 
@@ -53,13 +53,13 @@ export type Settings = {
    * Places a divider in the settings menu.
    * @param pos The position in the settings menu to place the divider
    */
-  addDivider: (pos: number | null) => void;
+  addDivider: (pos: number | ((section: unknown) => number) | null) => void;
 
   /**
    * Places a header in the settings menu.
    * @param pos The position in the settings menu to place the header
    */
-  addHeader: (label: string, pos: number | null) => void;
+  addHeader: (label: string, pos: number | ((section: unknown) => number) | null) => void;
 
   /**
    * @private


### PR DESCRIPTION
This PR allows you to dynamically calculate the position of your settings items (dividers, headers, sections).

Example:

```ts
settings.addDivider((sections) => {
  return sections.findIndex((section) => section.section === UserSettingsSections.DEVELOPER_OPTIONS);
});

settings.addHeader("Cool Header", (sections) => {
  return sections.findIndex((section) => section.section === UserSettingsSections.DEVELOPER_OPTIONS);
});

settings.addSection("SectionName", "Section Label",  SectionComponent, null, (sections) => {
  return sections.findIndex((section) => section.section === UserSettingsSections.DEVELOPER_OPTIONS);
});

```