### PR TITLE
Fix very laggy Sources tab in DevTools when using "Patch all" in Spacepack

### DIFF
--- a/packages/core-extensions/src/moonbase/webpackModules/crashScreen.tsx
+++ b/packages/core-extensions/src/moonbase/webpackModules/crashScreen.tsx
@@ -139,10 +139,10 @@ export function wrapAction({ action, state }: WrapperProps) {
   const causes = React.useMemo(() => {
     const causes = new Set<string>();
     if (state.error.stack) {
-      for (const [, id] of state.error.stack.matchAll(MODULE_REGEX))
+      for (const [, , id] of state.error.stack.matchAll(MODULE_REGEX))
         for (const ext of moonlight.patched.get(id) ?? []) causes.add(ext);
     }
-    for (const [, id] of state.info.componentStack.matchAll(MODULE_REGEX))
+    for (const [, , id] of state.info.componentStack.matchAll(MODULE_REGEX))
       for (const ext of moonlight.patched.get(id) ?? []) causes.add(ext);
     return [...causes];
   }, []);

--- a/packages/core-extensions/src/moonbase/webpackModules/crashScreen.tsx
+++ b/packages/core-extensions/src/moonbase/webpackModules/crashScreen.tsx
@@ -6,7 +6,7 @@ import { RepositoryManifest, UpdateState } from "../types";
 import { ConfigExtension, DetectedExtension } from "@moonlight-mod/types";
 import DiscoveryClasses from "@moonlight-mod/wp/discord/modules/discovery/web/Discovery.css";
 
-const MODULE_REGEX = /Webpack-Module-(\d+)\/(\d+)/g;
+const MODULE_REGEX = /Webpack-Module\/(\d+)\/(\d+)/g;
 
 const logger = moonlight.getLogger("moonbase/crashScreen");
 

--- a/packages/core-extensions/src/moonbase/webpackModules/crashScreen.tsx
+++ b/packages/core-extensions/src/moonbase/webpackModules/crashScreen.tsx
@@ -6,7 +6,7 @@ import { RepositoryManifest, UpdateState } from "../types";
 import { ConfigExtension, DetectedExtension } from "@moonlight-mod/types";
 import DiscoveryClasses from "@moonlight-mod/wp/discord/modules/discovery/web/Discovery.css";
 
-const MODULE_REGEX = /Webpack-Module-(\d+)/g;
+const MODULE_REGEX = /Webpack-Module-(\d+)\/(\d+)/g;
 
 const logger = moonlight.getLogger("moonbase/crashScreen");
 

--- a/packages/core-extensions/src/spacepack/webpackModules/spacepack.ts
+++ b/packages/core-extensions/src/spacepack/webpackModules/spacepack.ts
@@ -37,7 +37,7 @@ export const spacepack: Spacepack = {
       "module",
       "exports",
       "require",
-      `(${funcStr}).apply(this, arguments)\n` + `//# sourceURL=Webpack-Module-${module}`
+      `(${funcStr}).apply(this, arguments)\n` + `//# sourceURL=Webpack-Module-${module.slice(0, 3)}/${module}`
     ) as WebpackModuleFunc;
   },
 

--- a/packages/core-extensions/src/spacepack/webpackModules/spacepack.ts
+++ b/packages/core-extensions/src/spacepack/webpackModules/spacepack.ts
@@ -37,7 +37,7 @@ export const spacepack: Spacepack = {
       "module",
       "exports",
       "require",
-      `(${funcStr}).apply(this, arguments)\n` + `//# sourceURL=Webpack-Module-${module.slice(0, 3)}/${module}`
+      `(${funcStr}).apply(this, arguments)\n` + `//# sourceURL=Webpack-Module/${module.slice(0, 3)}/${module}`
     ) as WebpackModuleFunc;
   },
 

--- a/packages/core/src/patch.ts
+++ b/packages/core/src/patch.ts
@@ -79,7 +79,7 @@ function patchModules(entry: WebpackJsonpEntry[1]) {
     const wrapped =
       `(${replaced}).apply(this, arguments)\n` +
       `// Patched by moonlight: ${patchedStr}\n` +
-      `//# sourceURL=Webpack-Module-${id}`;
+      `//# sourceURL=Webpack-Module-${id.slice(0, 3)}/${id}`;
 
     try {
       const func = new Function("module", "exports", "require", wrapped) as WebpackModuleFunc;
@@ -205,7 +205,8 @@ function patchModules(entry: WebpackJsonpEntry[1]) {
 
     if (moonlightNode.config.patchAll === true) {
       if ((typeof id !== "string" || !id.includes("_")) && !entry[id].__moonlight) {
-        const wrapped = `(${moduleCache[id]}).apply(this, arguments)\n` + `//# sourceURL=Webpack-Module-${id}`;
+        const wrapped =
+          `(${moduleCache[id]}).apply(this, arguments)\n` + `//# sourceURL=Webpack-Module-${id.slice(0, 3)}/${id}`;
         entry[id] = new Function("module", "exports", "require", wrapped) as WebpackModuleFunc;
         entry[id].__moonlight = true;
       }

--- a/packages/core/src/patch.ts
+++ b/packages/core/src/patch.ts
@@ -79,7 +79,7 @@ function patchModules(entry: WebpackJsonpEntry[1]) {
     const wrapped =
       `(${replaced}).apply(this, arguments)\n` +
       `// Patched by moonlight: ${patchedStr}\n` +
-      `//# sourceURL=Webpack-Module-${id.slice(0, 3)}/${id}`;
+      `//# sourceURL=Webpack-Module/${id.slice(0, 3)}/${id}`;
 
     try {
       const func = new Function("module", "exports", "require", wrapped) as WebpackModuleFunc;
@@ -206,7 +206,7 @@ function patchModules(entry: WebpackJsonpEntry[1]) {
     if (moonlightNode.config.patchAll === true) {
       if ((typeof id !== "string" || !id.includes("_")) && !entry[id].__moonlight) {
         const wrapped =
-          `(${moduleCache[id]}).apply(this, arguments)\n` + `//# sourceURL=Webpack-Module-${id.slice(0, 3)}/${id}`;
+          `(${moduleCache[id]}).apply(this, arguments)\n` + `//# sourceURL=Webpack-Module/${id.slice(0, 3)}/${id}`;
         entry[id] = new Function("module", "exports", "require", wrapped) as WebpackModuleFunc;
         entry[id].__moonlight = true;
       }


### PR DESCRIPTION
The problem: DevTools Sources tab is incredibly laggy
The cause: Using "Patch all" creates hundreds of thousands of modules in one directory which is a lot to render in the sidebar and the list isn't virtualized
The solution: Group patched webpack modules by the first 3 chars of the ID, reducing the amount of rendered files in the sidebar

~~Also my moonbase disappeared but I reverted my changes and it's still gone so maybe unrelated? I need to test if the crash screen works properly but I can't install Crash Me right now.~~ it was my fault