### PR TITLE
nativeFixes: Add Vulkan and VAAPI driver check ignore options

### DIFF
--- a/packages/core-extensions/src/nativeFixes/host.ts
+++ b/packages/core-extensions/src/nativeFixes/host.ts
@@ -29,6 +29,10 @@ if (moonlightHost.getConfigOption<boolean>("nativeFixes", "disableRendererBackgr
   app.commandLine.appendSwitch("disable-background-timer-throttling");
 }
 
+if (moonlightHost.getConfigOption<boolean>("nativeFixes", "vulkan") ?? false) {
+  enabledFeatures.push("Vulkan", "DefaultANGLEVulkan", "VulkanFromANGLE");
+}
+
 if (process.platform === "linux") {
   if (moonlightHost.getConfigOption<boolean>("nativeFixes", "linuxAutoscroll") ?? false) {
     app.commandLine.appendSwitch("enable-blink-features", "MiddleClickAutoscroll");
@@ -43,9 +47,13 @@ if (process.platform === "linux") {
 //       hardware acceleration is disabled
 const noAccel = app.commandLine.hasSwitch("disable-gpu-compositing");
 if ((moonlightHost.getConfigOption<boolean>("nativeFixes", "vaapi") ?? true) && !noAccel) {
-  if (process.platform === "linux")
+  if (process.platform === "linux") {
     // These will eventually be renamed https://source.chromium.org/chromium/chromium/src/+/5482210941a94d70406b8da962426e4faca7fce4
     enabledFeatures.push("VaapiVideoEncoder", "VaapiVideoDecoder", "VaapiVideoDecodeLinuxGL");
+
+    if (moonlightHost.getConfigOption<boolean>("nativeFixes", "vaapiIgnoreDriverChecks") ?? false)
+      enabledFeatures.push("VaapiIgnoreDriverChecks");
+  }
 }
 
 app.commandLine.appendSwitch("enable-features", [...new Set(enabledFeatures)].join(","));

--- a/packages/core-extensions/src/nativeFixes/manifest.json
+++ b/packages/core-extensions/src/nativeFixes/manifest.json
@@ -23,6 +23,13 @@
       "type": "boolean",
       "default": true
     },
+    "vulkan": {
+      "advice": "restart",
+      "displayName": "Enable Vulkan renderer",
+      "description": "Uses the Vulkan backend for rendering",
+      "type": "boolean",
+      "default": false
+    },
     "linuxAutoscroll": {
       "advice": "restart",
       "displayName": "Enable middle click autoscroll on Linux",
@@ -43,6 +50,13 @@
       "description": "Provides hardware accelerated video encode and decode. Has no effect on other operating systems",
       "type": "boolean",
       "default": true
+    },
+    "vaapiIgnoreDriverChecks": {
+      "advice": "restart",
+      "displayName": "Ignore VAAPI driver checks on Linux",
+      "description": "Forces hardware video acceleration on some graphics drivers at the cost of stability. Has no effect on other operating systems",
+      "type": "boolean",
+      "default": false
     },
     "linuxUpdater": {
       "advice": "restart",


### PR DESCRIPTION
These options are necessary for hardware accelerated (or possibly in general?) H.265 playback on Linux. The `vaapiIgnoreDriverChecks` option requires `vaapi` to be enabled as well, but there's currently no way to force specific options.