### PR TITLE
WIP: Update Nix flake for pnpm 10

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,98 +18,29 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728067476,
-        "narHash": "sha256-/uJcVXuBt+VFCPQIX+4YnYrHaubJSx4HoNsJVNRgANM=",
+        "lastModified": 1744232761,
+        "narHash": "sha256-gbl9hE39nQRpZaLjhWKmEu5ejtQsgI5TWYrIVVJn30U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6e6b3dd395c3b1eb9be9f2d096383a8d05add030",
+        "rev": "f675531bc7e6657c10a18b565cfebd8aa9e24c14",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1736344531,
-        "narHash": "sha256-8YVQ9ZbSfuUk2bUf2KRj60NRraLPKPS0Q4QFTbc+c2c=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "bffc22eb12172e6db3c5dde9e3e5628f8e3e7912",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "pnpm2nix": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1736457458,
-        "narHash": "sha256-eiw+hAsxavEgBfhwrktNI2hwvgeVDzBDYClx/yqka78=",
-        "owner": "NotNite",
-        "repo": "pnpm2nix-nzbr",
-        "rev": "4ac61c6a50623da937dca005e3dbcb8862aafb83",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NotNite",
-        "repo": "pnpm2nix-nzbr",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "pnpm2nix": "pnpm2nix"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -2,13 +2,12 @@
   description = "Yet another Discord mod";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    pnpm2nix.url = "github:NotNite/pnpm2nix-nzbr";
   };
 
-  outputs = { self, nixpkgs, flake-utils, pnpm2nix }:
-    let overlay = import ./nix/overlay.nix { inherit pnpm2nix; };
+  outputs = { self, nixpkgs, flake-utils }:
+    let overlay = import ./nix/overlay.nix { };
     in flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,28 +1,51 @@
-{ pkgs, mkPnpmPackage }:
+{
+  lib,
+  stdenv,
+  nodejs_22,
+  pnpm_10,
+}:
 
-mkPnpmPackage rec {
-  workspace = ./..;
+stdenv.mkDerivation (finalAttrs: {
+  pname = "moonlight";
+  version = (builtins.fromJSON (builtins.readFile ./../package.json)).version;
+
   src = ./..;
 
-  # Work around a bug with how it expects dist
-  components = [
-    "packages/core"
-    "packages/core-extensions"
-    "packages/injector"
-    "packages/node-preload"
-    "packages/types"
-    "packages/web-preload"
+  nativeBuildInputs = [
+    nodejs_22
+    pnpm_10.configHook
   ];
-  distDirs = [ "dist" ];
 
-  copyNodeModules = true;
-  buildPhase = "pnpm run build";
-  installPhase = "cp -r dist $out";
+  pnpmDeps = pnpm_10.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-JYHoTZuk0z1Tn39R5j0UJ41yZVNF0PpzrgkLzfCrxHI=";
+  };
 
-  meta = with pkgs.lib; {
+  env = {
+    NODE_ENV = "production";
+    MOONLIGHT_VERSION = "v${finalAttrs.version}";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r dist $out
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
     description = "Yet another Discord mod";
     homepage = "https://moonlight-mod.github.io/";
     license = licenses.lgpl3;
     maintainers = with maintainers; [ notnite ];
   };
-}
+})

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,4 +1,4 @@
-{ pnpm2nix }:
+{ ... }:
 
 let
   nameTable = {
@@ -49,10 +49,7 @@ let
       '';
     });
 in final: prev: rec {
-  moonlight-mod = final.callPackage ./default.nix {
-    pkgs = final;
-    mkPnpmPackage = pnpm2nix.packages.${final.system}.mkPnpmPackage;
-  };
+  moonlight-mod = final.callPackage ./default.nix { };
   discord = mkOverride prev moonlight-mod "discord";
   discord-ptb = mkOverride prev moonlight-mod "discord-ptb";
   discord-canary = mkOverride prev moonlight-mod "discord-canary";


### PR DESCRIPTION
pain, furthermore suffering

- this uses the new approach from nixpkgs
- note that `MOONLIGHT_BRANCH` isn't set, I have no idea if there's a sensible thing to set it to here (unless you want to change the nix packaging for each stable/not-stable release)
- also, the hash for the `fetchDeps` FOD will need updating whenever the dependencies change I guess? (and needs filling in to start with...)

the problem: nixos-24.11 has pnpm_10 built with nodejs_20, afaict. this breaks everything:

```
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/x49iyngv15bw7qikpx75qwnjmqfqsh1y-2a1i741ln5mc1gv85nxkybyn8a6dx943-source
source root is 2a1i741ln5mc1gv85nxkybyn8a6dx943-source
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: installPhase
@nix { "action": "setPhase", "phase": "installPhase" }
/build /build/2a1i741ln5mc1gv85nxkybyn8a6dx943-source
/build/2a1i741ln5mc1gv85nxkybyn8a6dx943-source
 ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)

Your Node version is incompatible with "/build/2a1i741ln5mc1gv85nxkybyn8a6dx943-source".

Expected version: >=22
Got: v20.19.0

This is happening because the package's manifest has an engines.node field specified.
To fix this issue, install the required Node version.
```