### PR TITLE
Add GHA workflow to ensure Nix flake builds

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,16 @@
+name: Check Nix flake
+on: [push, pull_request]
+
+permissions:
+  checks: write
+
+jobs:
+  nix:
+    name: Check Nix flake
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Build default flake output
+        run: nix build


### PR DESCRIPTION
this basically works. an example of how it looks: https://github.com/sersorrel/moonlight/actions/runs/14475141013/job/40598855793

![image](https://github.com/user-attachments/assets/8097c9d3-2485-4118-baae-5924c6c147a3)

it would be nice to surface the error somewhere a bit more obvious, i don't really have enough experience with GHA to know what kinds of things are possible

shout if you have super negative opinions about the determinate nix installer or want me to point it to lix or something