### PR TITLE
Moonbase config fixes

### DIFF
--- a/packages/core-extensions/src/moonbase/webpackModules/crashScreen.tsx
+++ b/packages/core-extensions/src/moonbase/webpackModules/crashScreen.tsx
@@ -84,7 +84,7 @@ function ExtensionUpdateCard({ id, ext }: UpdateCardProps) {
 }
 
 function ExtensionDisableCard({ ext }: { ext: DetectedExtension }) {
-  function disableWithDependents() {
+  async function disableWithDependents() {
     const disable = new Set<string>();
     disable.add(ext.id);
     for (const [id, dependencies] of moonlightNode.processedExtensions.dependencyGraph) {
@@ -105,7 +105,7 @@ function ExtensionDisableCard({ ext }: { ext: DetectedExtension }) {
     msg += "?";
 
     if (confirm(msg)) {
-      moonlightNode.writeConfig(config);
+      await moonlightNode.writeConfig(config);
       window.location.reload();
     }
   }

--- a/packages/core-extensions/src/moonbase/webpackModules/settings.tsx
+++ b/packages/core-extensions/src/moonbase/webpackModules/settings.tsx
@@ -19,8 +19,8 @@ const notice = {
         onReset={() => {
           MoonbaseSettingsStore.reset();
         }}
-        onSave={() => {
-          MoonbaseSettingsStore.writeConfig();
+        onSave={async () => {
+          await MoonbaseSettingsStore.writeConfig();
         }}
       />
     );

--- a/packages/core-extensions/src/moonbase/webpackModules/stores.ts
+++ b/packages/core-extensions/src/moonbase/webpackModules/stores.ts
@@ -239,7 +239,7 @@ class MoonbaseSettingsStore extends Store<any> {
     let val = this.config.extensions[ext.id];
 
     if (val == null) {
-      this.config.extensions[ext.id] = { enabled };
+      this.config.extensions[ext.id] = enabled;
       this.modified = this.isModified();
       this.emitChange();
       return;

--- a/packages/core-extensions/src/moonbase/webpackModules/stores.ts
+++ b/packages/core-extensions/src/moonbase/webpackModules/stores.ts
@@ -83,11 +83,11 @@ class MoonbaseSettingsStore extends Store<any> {
     this.checkUpdates();
 
     // Update our state if another extension edited the config programatically
-    moonlightNode.events.addEventListener(NodeEventType.ConfigSaved, async (config) => {
+    moonlightNode.events.addEventListener(NodeEventType.ConfigSaved, (config) => {
       if (!this.submitting) {
         this.config = this.clone(config);
-        await this.processConfigChanged();
-        this.emitChange();
+        // NOTE: This is also async but we're calling it without
+        this.processConfigChanged();
       }
     });
   }
@@ -513,6 +513,8 @@ class MoonbaseSettingsStore extends Store<any> {
   async writeConfig() {
     try {
       this.submitting = true;
+      this.emitChange();
+
       await moonlightNode.writeConfig(this.config);
       await this.processConfigChanged();
     } finally {
@@ -528,6 +530,8 @@ class MoonbaseSettingsStore extends Store<any> {
 
     const modifiedRepos = diff(this.savedConfig.repositories, this.config.repositories);
     if (modifiedRepos.length !== 0) await this.checkUpdates();
+
+    this.emitChange();
   }
 
   reset() {


### PR DESCRIPTION
Some minor things I noticed when working on the CSS extension rewrite:

- Moonbase writes new extensions as `{"enabled": true}`, which just looks bad when editing the JSON by hand, even if it's functionally the same. Now, it writes the shorthand (`true`). Other parts of Moonbase will convert the object when required, like it always has.
- Extensions that call `MoonlightNode#writeConfig` don't have their changes show up in Moonbase (since we aren't copying the new config). To solve this, I just split off the actual config processing logic into a new function, and listen to the event to update the store's state. `MoonbaseSettingsStore#writeConfig` will cause the event to fire, which means it works the same as the original code, just with a more indirect path (and AFAIK it'll fire sync so there shouldn't be a possibility for a race condition).
- Fixed some other issues where we weren't properly `await`ing things. Whoops.