### PR TITLE
Apply styles to popout and overlay

### DIFF
--- a/packages/core/src/styles.ts
+++ b/packages/core/src/styles.ts
@@ -4,10 +4,10 @@ export function registerStyles(style: string[]) {
   styles.push(...style);
 }
 
-export function installStyles() {
+export function installStyles(doc: Document) {
   for (const style of styles) {
-    const el = document.createElement("style");
+    const el = doc.createElement("style");
     el.textContent = style;
-    document.documentElement.appendChild(el);
+    doc.documentElement.appendChild(el);
   }
 }

--- a/packages/web-preload/src/index.ts
+++ b/packages/web-preload/src/index.ts
@@ -55,10 +55,27 @@ async function load() {
   }
 
   if (document.readyState === "complete") {
-    installStyles();
+    installStyles(document);
   } else {
-    window.addEventListener("load", installStyles);
+    window.addEventListener("load", () => installStyles(document));
   }
+
+  // Install styles into popout/overlay
+  const oldWindowOpen = window.open;
+  window.open = function (...args) {
+    const proxy = oldWindowOpen.call(this, ...args);
+
+    if (proxy) {
+      proxy.addEventListener("load", () => {
+        const hostname = proxy.window.location.hostname;
+        if (hostname.endsWith("discord.com") || hostname.endsWith("discordapp.com")) {
+          installStyles(proxy.window.document);
+        }
+      });
+    }
+
+    return proxy;
+  };
 }
 
 window._moonlightWebLoad = load;


### PR DESCRIPTION
The popout and new overlay create separate windows with `window.open` from web, where our styles aren't loaded, breaking some extensions that modify chat. I originally thought I had to mess around with the `setWindowOpenHandler` function in Electron, but it turns out monkeypatching `window.open` gets us a reference to the window, which is both patchless and less complicated.

Tested with Mention Avatars in the overlay and Pronouns in the popout.