### PR TITLE
Better script blocking

### DIFF
--- a/packages/browser/src/background-mv2.js
+++ b/packages/browser/src/background-mv2.js
@@ -9,13 +9,10 @@ chrome.webRequest.onBeforeRequest.addListener(
     if (details.tabId === -1) return;
 
     const url = new URL(details.url);
-    const hasUrl = scriptUrls.some((scriptUrl) => {
-      return (
-        details.url.includes(scriptUrl) &&
-        !url.searchParams.has("inj") &&
-        (url.host.endsWith("discord.com") || url.host.endsWith("discordapp.com"))
-      );
-    });
+    const hasUrl =
+      url.pathname.match(/\/assets\/[a-zA-Z]+\./) &&
+      !url.searchParams.has("inj") &&
+      (url.host.endsWith("discord.com") || url.host.endsWith("discordapp.com"));
     if (hasUrl) blockedScripts.add(details.url);
 
     if (blockedScripts.size === scriptUrls.length) {
@@ -44,7 +41,7 @@ chrome.webRequest.onBeforeRequest.addListener(
 
               blockedScripts.reverse();
               for (const url of blockedScripts) {
-                if (url.includes("/sentry.")) continue;
+                if (!url.includes("/web.")) continue;
 
                 const script = scripts.find((script) => url.includes(script.src));
                 const newScript = document.createElement("script");

--- a/packages/browser/src/background.js
+++ b/packages/browser/src/background.js
@@ -22,14 +22,10 @@ chrome.webRequest.onBeforeRequest.addListener(
     if (details.tabId === -1) return;
 
     const url = new URL(details.url);
-    const hasUrl = scriptUrls.some((scriptUrl) => {
-      return (
-        details.url.includes(scriptUrl) &&
-        !url.searchParams.has("inj") &&
-        (url.hostname.endsWith("discord.com") || url.hostname.endsWith("discordapp.com"))
-      );
-    });
-
+    const hasUrl =
+      url.pathname.match(/\/assets\/[a-zA-Z]+\./) &&
+      !url.searchParams.has("inj") &&
+      (url.hostname.endsWith("discord.com") || url.hostname.endsWith("discordapp.com"));
     if (hasUrl) blockedScripts.add(details.url);
 
     if (blockedScripts.size === scriptUrls.length) {
@@ -87,7 +83,7 @@ chrome.webRequest.onBeforeRequest.addListener(
 
             blockedScripts.reverse();
             for (const url of blockedScripts) {
-              if (url.includes("/sentry.")) continue;
+              if (!url.includes("/web.")) continue;
 
               const script = scripts.find((script) => url.includes(script.src));
               const newScript = document.createElement("script");

--- a/packages/core/src/patch.ts
+++ b/packages/core/src/patch.ts
@@ -408,10 +408,6 @@ export async function installWebpackPatcher() {
   let realWebpackJsonp: WebpackJsonp | null = null;
   Object.defineProperty(window, "webpackChunkdiscord_app", {
     set: (jsonp: WebpackJsonp) => {
-      // Don't let Sentry mess with Webpack
-      const stack = new Error().stack!;
-      if (stack.includes("sentry.")) return;
-
       realWebpackJsonp = jsonp;
       const realPush = jsonp.push;
       if (jsonp.push.__moonlight !== true) {
@@ -453,8 +449,6 @@ export async function installWebpackPatcher() {
     },
 
     get: () => {
-      const stack = new Error().stack!;
-      if (stack.includes("sentry.")) return [];
       return realWebpackJsonp;
     }
   });

--- a/packages/injector/src/index.ts
+++ b/packages/injector/src/index.ts
@@ -177,13 +177,10 @@ class BrowserWindow extends ElectronBrowserWindow {
       */
       if (details.resourceType === "script" && isMainWindow) {
         const url = new URL(details.url);
-        const hasUrl = scriptUrls.some((scriptUrl) => {
-          return (
-            details.url.includes(scriptUrl) &&
-            !url.searchParams.has("inj") &&
-            (url.host.endsWith("discord.com") || url.host.endsWith("discordapp.com"))
-          );
-        });
+        const hasUrl =
+          url.pathname.match(/\/assets\/[a-zA-Z]+\./) &&
+          !url.searchParams.has("inj") &&
+          (url.host.endsWith("discord.com") || url.host.endsWith("discordapp.com"));
         if (hasUrl) blockedScripts.add(details.url);
 
         if (blockedScripts.size === scriptUrls.length) {

--- a/packages/node-preload/src/index.ts
+++ b/packages/node-preload/src/index.ts
@@ -164,7 +164,7 @@ if (isOverlay) {
 
           blockedScripts.reverse();
           for (const url of blockedScripts) {
-            if (url.includes("/sentry.")) continue;
+            if (!url.includes("/web.")) continue;
 
             const script = scripts.find((script) => url.includes(script.src))!;
             const newScript = document.createElement("script");


### PR DESCRIPTION
Uses a regex to block entry scripts so the scriptUrls array doesn't have to be changed all the time.

Since every entry script redefines Webpack internals when it loads, it shouldn't cause issues with all of them that aren't `web` being blocked.