### PR TITLE
nativeFixes: Add disableFontations

### DIFF
--- a/packages/core-extensions/src/nativeFixes/manifest.json
+++ b/packages/core-extensions/src/nativeFixes/manifest.json
@@ -71,6 +71,13 @@
       "description": "You might also need to enable Vulkan renderer. Has no effect on other operating systems",
       "type": "boolean",
       "default": true
+    },
+    "disableFontations": {
+      "advice": "restart",
+      "displayName": "Disable Fontations on Linux",
+      "description": "May improve blurry font rendering. Has no effect on other operating systems",
+      "type": "boolean",
+      "default": false
     }
   },
   "apiLevel": 2


### PR DESCRIPTION
Ran into a "fun" issue where Discord set its own `disable-features` in app_bootstrap that overwrote ours, so I had to add a monkeypatch for the Electron function.