### PR TITLE
Refactor flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,26 +6,55 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    let overlay = import ./nix/overlay.nix { };
-    in flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    let
+      overlay = import ./nix/overlay.nix { inherit self; };
+    in
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
-        pkgs = import nixpkgs {
-          inherit system;
-          config.allowUnfree = true;
-          overlays = [ overlay ];
-        };
-      in {
-        # Don't use these unless you're testing things
-        packages.default = pkgs.moonlight-mod;
-        packages.moonlight-mod = pkgs.moonlight-mod;
+        # https://discourse.nixos.org/t/different-ways-of-populating-pkgs-variable/29109/2
+        pkgs = nixpkgs.legacyPackages.${system};
 
-        packages.discord = pkgs.discord;
-        packages.discord-ptb = pkgs.discord-ptb;
-        packages.discord-canary = pkgs.discord-canary;
-        packages.discord-development = pkgs.discord-development;
-      }) // {
-        overlays.default = overlay;
-        homeModules.default = ./nix/home-manager.nix;
-      };
+        # Deprecated
+        overlay-pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ overlay ];
+          # Workaround to accept discord package license on user's behalf
+          config.allowUnfree = true;
+        };
+      in
+      {
+        packages = {
+          default = self.packages.${system}.moonlight;
+          moonlight = pkgs.callPackage ./nix { };
+
+          # Deprecated alias
+          moonlight-mod =
+            builtins.warn
+              "The moonlight package 'moonlight-mod' is deprecated and will be removed in a future release. Use 'moonlight' instead"
+              self.packages.${system}.moonlight;
+
+          # Deprecated packages
+          inherit (overlay-pkgs)
+            discord
+            discord-ptb
+            discord-canary
+            discord-development
+            ;
+        };
+
+        formatter = pkgs.nixfmt-rfc-style;
+      }
+    )
+    // {
+      homeModules.default = ./nix/home-manager.nix;
+      # Deprecated overlay
+      overlays.default = builtins.warn "The moonlight overlay is deprecated and will be removed in a future release." overlay;
+    };
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -11,7 +11,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = ./..;
 
-  outputs = [ "out" "firefox" ];
+  outputs = [
+    "out"
+    "firefox"
+  ];
 
   nativeBuildInputs = [
     nodejs_22

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -1,56 +1,64 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  ...
+}:
 
-let cfg = config.programs.moonlight-mod;
-in {
-  options.programs.moonlight-mod = {
+let
+  cfg = config.programs.moonlight-mod;
+in
+{
+  imports = [
+    (lib.mkRenamedOptionModule [ "programs" "moonlight-mod" ] [ "programs" "moonlight" ])
+  ];
+
+  options.programs.moonlight = {
     enable = lib.mkEnableOption "Yet another Discord mod";
 
-    configs = let
-      # TODO: type this
-      type = lib.types.nullOr (lib.types.attrs);
-      default = null;
-    in {
-      stable = lib.mkOption {
-        inherit type default;
-        description = "Configuration for Discord Stable";
-      };
+    configs =
+      let
+        # TODO: type this
+        type = lib.types.nullOr lib.types.attrs;
+        default = null;
+      in
+      {
+        stable = lib.mkOption {
+          inherit type default;
+          description = "Configuration for Discord Stable";
+        };
 
-      ptb = lib.mkOption {
-        inherit type default;
-        description = "Configuration for Discord PTB";
-      };
+        ptb = lib.mkOption {
+          inherit type default;
+          description = "Configuration for Discord PTB";
+        };
 
-      canary = lib.mkOption {
-        inherit type default;
-        description = "Configuration for Discord Canary";
-      };
+        canary = lib.mkOption {
+          inherit type default;
+          description = "Configuration for Discord Canary";
+        };
 
-      development = lib.mkOption {
-        inherit type default;
-        description = "Configuration for Discord Development";
+        development = lib.mkOption {
+          inherit type default;
+          description = "Configuration for Discord Development";
+        };
       };
-    };
   };
 
   config = lib.mkIf cfg.enable {
-    xdg.configFile."moonlight-mod/stable.json" =
-      lib.mkIf (cfg.configs.stable != null) {
-        text = builtins.toJSON cfg.configs.stable;
-      };
+    xdg.configFile."moonlight-mod/stable.json" = lib.mkIf (cfg.configs.stable != null) {
+      text = builtins.toJSON cfg.configs.stable;
+    };
 
-    xdg.configFile."moonlight-mod/ptb.json" =
-      lib.mkIf (cfg.configs.ptb != null) {
-        text = builtins.toJSON cfg.configs.ptb;
-      };
+    xdg.configFile."moonlight-mod/ptb.json" = lib.mkIf (cfg.configs.ptb != null) {
+      text = builtins.toJSON cfg.configs.ptb;
+    };
 
-    xdg.configFile."moonlight-mod/canary.json" =
-      lib.mkIf (cfg.configs.canary != null) {
-        text = builtins.toJSON cfg.configs.canary;
-      };
+    xdg.configFile."moonlight-mod/canary.json" = lib.mkIf (cfg.configs.canary != null) {
+      text = builtins.toJSON cfg.configs.canary;
+    };
 
-    xdg.configFile."moonlight-mod/development.json" =
-      lib.mkIf (cfg.configs.development != null) {
-        text = builtins.toJSON cfg.configs.development;
-      };
+    xdg.configFile."moonlight-mod/development.json" = lib.mkIf (cfg.configs.development != null) {
+      text = builtins.toJSON cfg.configs.development;
+    };
   };
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,57 +1,25 @@
-{ ... }:
+{ self }:
 
-let
-  nameTable = {
-    discord = "Discord";
-    discord-ptb = "DiscordPTB";
-    discord-canary = "DiscordCanary";
-    discord-development = "DiscordDevelopment";
-  };
-
-  darwinNameTable = {
-    discord = "Discord";
-    discord-ptb = "Discord PTB";
-    discord-canary = "Discord Canary";
-    discord-development = "Discord Development";
-  };
-
-  mkOverride = prev: moonlight: name:
-    let discord = prev.${name};
-    in discord.overrideAttrs (old: {
-      installPhase = let
-        folderName = nameTable.${name};
-        darwinFolderName = darwinNameTable.${name};
-
-        injected = ''
-          require("${moonlight}/injector").inject(
-            require("path").join(__dirname, "../_app.asar")
-          );
-        '';
-
-        packageJson = ''
-          {"name":"${name}","main":"./injector.js","private":true}
-        '';
-
-      in old.installPhase + "\n" + ''
-        resources="$out/opt/${folderName}/resources"
-        if [ ! -d "$resources" ]; then
-          resources="$out/Applications/${darwinFolderName}.app/Contents/Resources"
-        fi
-
-        mv "$resources/app.asar" "$resources/_app.asar"
-        mkdir -p "$resources/app"
-
-        cat > "$resources/app/injector.js" <<EOF
-        ${injected}
-        EOF
-
-        echo '${packageJson}' > "$resources/app/package.json"
-      '';
-    });
-in final: prev: rec {
-  moonlight-mod = final.callPackage ./default.nix { };
-  discord = mkOverride prev moonlight-mod "discord";
-  discord-ptb = mkOverride prev moonlight-mod "discord-ptb";
-  discord-canary = mkOverride prev moonlight-mod "discord-canary";
-  discord-development = mkOverride prev moonlight-mod "discord-development";
-}
+final: prev:
+prev.lib.genAttrs
+  [
+    "discord"
+    "discord-ptb"
+    "discord-canary"
+    "discord-development"
+  ]
+  (name: {
+    inherit name;
+    value =
+      builtins.warn
+        ''
+          The moonlight package '${name}' is deprecated and will be removed in a future release.
+          Please use 'discord.override {withMoonlight = true;}' instead.
+          For instructions see: https://moonlight-mod.github.io/using/install/#nixpkgs
+        ''
+        prev.${name}.override
+        {
+          withMoonlight = true;
+          moonlight = self.packages.${prev.system}.moonlight;
+        };
+  })


### PR DESCRIPTION
## Changes

There should be no breaking changes here, only refactoring and deprecating behavior

### Discord packages now use `withMoonlight`

Now using the withMoonlight feature of the nixpkgs Discord derivation to patch with moonlight

### Deprecated all Discord packages

The Discord packages used a nixpkgs instance with `config.allowUnfree` pre-enabled as a workaround for Discord's unfree license

There isn't much reason to provide overridden Discord packages, so these have been deprecated

These packages still function, but will throw an evaluation warning:

```
evaluation warning: The moonlight package 'discord' is deprecated and will be removed in a future release.
                    Please use 'discord.override {withMoonlight = true;}' instead.
                    For instructions see: https://moonlight-mod.github.io/using/install/#nixpkgs
```

### Deprecated the overlay as overlays are generally confusing and inefficient

The new method for users to get the latest version of moonlight is to use the flake's `moonlight` package directly like so:

```
discord.override {
  withMoonlight = true;
  moonlight = inputs.moonlight.packages.${pkgs.system}.moonlight;
};
```

Attempting to use the overlay will still function, but now throws:

```
evaluation warning: The moonlight overlay is deprecated and will be removed in a future release.
```

### Rename `moonlight-mod` package to `moonlight`

To bring it inline with nixpkgs, the old alias is still available and is deprecated producing an evaluation warning:

```
evaluation warning: The moonlight package 'moonlight-mod' is deprecated and will be removed in a future release. Use 'moonlight' instead
```

### Set nixfmt-rfc-style as formatter

This is the formatter used in nixpkgs, I don't believe a formatter was already in use