### PR TITLE
Add frame-src to the list of directives for extending the Content-Security-Policy header

### DIFF
--- a/packages/injector/src/index.ts
+++ b/packages/injector/src/index.ts
@@ -74,7 +74,16 @@ ipcMain.handle(constants.ipcSetBlockedList, (_, list: string[]) => {
 });
 
 function patchCsp(headers: Record<string, string[]>, extensionCspOverrides: Record<string, string[]>) {
-  const directives = ["script-src", "style-src", "connect-src", "img-src", "font-src", "media-src", "worker-src"];
+  const directives = [
+    "script-src",
+    "frame-src",
+    "style-src",
+    "connect-src",
+    "img-src",
+    "font-src",
+    "media-src",
+    "worker-src"
+  ];
   const values = ["*", "blob:", "data:", "'unsafe-inline'", "'unsafe-eval'", "disclip:"];
 
   const csp = "content-security-policy";


### PR DESCRIPTION
This adds the `frame-src` directive to the list defined in https://github.com/moonlight-mod/moonlight/pull/202. It prevents the error

```
Refused to frame 'https://your.domain/' because it violates the following Content Security Policy directive: "frame-src <list of urls>".
```

when extensions try to add custom `iframe`s, since they also need to have their domains included in the Content-Security-Policy header.

You can test with a simple extension that just lists `https://your.domain` in `csp.script-src`, and then placing an `iframe` with that domain anywhere in the DOM.

 __

As an aside, I think it's more intuitive to separate the `script-src` field in manifest into multiple---one for each directive. It's not immediately clear that dropping a domain here also amends `style-src` or `img-src`, for example. But this would probably be a breaking change.
