### PR TITLE
nix: Use lib.warn rather than builtins.warn

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,7 @@
     }:
     let
       overlay = import ./nix/overlay.nix { inherit self; };
+      inherit (nixpkgs) lib;
     in
     flake-utils.lib.eachDefaultSystem (
       system:
@@ -36,7 +37,7 @@
 
           # Deprecated alias
           moonlight-mod =
-            builtins.warn
+            lib.warn
               "The moonlight package 'moonlight-mod' is deprecated and will be removed in a future release. Use 'moonlight' instead"
               self.packages.${system}.moonlight;
 
@@ -55,6 +56,6 @@
     // {
       homeModules.default = ./nix/home-manager.nix;
       # Deprecated overlay
-      overlays.default = builtins.warn "The moonlight overlay is deprecated and will be removed in a future release." overlay;
+      overlays.default = lib.warn "The moonlight overlay is deprecated and will be removed in a future release." overlay;
     };
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -11,7 +11,7 @@ prev.lib.genAttrs
   (name: {
     inherit name;
     value =
-      builtins.warn
+      prev.lib.warn
         ''
           The moonlight package '${name}' is deprecated and will be removed in a future release.
           Please use 'discord.override {withMoonlight = true;}' instead.


### PR DESCRIPTION
something I didn't notice when looking at #258: `builtins.warn` is [unavailable](https://git.lix.systems/lix-project/lix/issues/579) in Lix, so moonlight currently doesn't work with that implementation:

```
error:
       … while evaluating an expression to select 'drvPath' on it
         at «internal»:1:552:
       … while evaluating strict
         at «internal»:1:552:
       (stack trace truncated; use '--show-trace' to show the full trace)

       error: attribute 'warn' missing
       at /nix/store/m8dw9wmjhzyqj8gk3cfm408cvymmgnl1-source/flake.nix:58:35:
           57|       # Deprecated overlay
           58|       overlays.default = builtins.warn "The moonlight overlay is deprecated and will be removed in a future release." overlay;
             |                                   ^
           59|     };
```

`lib.warn` behaves similarly and works everywhere.