### PR TITLE
Nix compatibility fixes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
 
           # Deprecated alias
           moonlight-mod =
-            builtins.warn
+            nixpkgs.lib.warn
               "The moonlight package 'moonlight-mod' is deprecated and will be removed in a future release. Use 'moonlight' instead"
               self.packages.${system}.moonlight;
 
@@ -55,6 +55,6 @@
     // {
       homeModules.default = ./nix/home-manager.nix;
       # Deprecated overlay
-      overlays.default = builtins.warn "The moonlight overlay is deprecated and will be removed in a future release." overlay;
+      overlays.default = nixpkgs.lib.warn "The moonlight overlay is deprecated and will be removed in a future release." overlay;
     };
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -8,18 +8,17 @@ prev.lib.genAttrs
     "discord-canary"
     "discord-development"
   ]
-  (name: {
-    inherit name;
-    value =
-      builtins.warn
-        ''
-          The moonlight package '${name}' is deprecated and will be removed in a future release.
-          Please use 'discord.override {withMoonlight = true;}' instead.
-          For instructions see: https://moonlight-mod.github.io/using/install/#nixpkgs
-        ''
-        prev.${name}.override
-        {
-          withMoonlight = true;
-          moonlight = self.packages.${prev.system}.moonlight;
-        };
-  })
+  (
+    name:
+    prev.lib.warn
+      ''
+        The moonlight package '${name}' is deprecated and will be removed in a future release.
+        Please use 'discord.override {withMoonlight = true;}' instead.
+        For instructions see: https://moonlight-mod.github.io/using/install/#nixpkgs
+      ''
+      prev.${name}.override
+      {
+        withMoonlight = true;
+        moonlight = self.packages.${prev.system}.moonlight;
+      }
+  )


### PR DESCRIPTION
Small tweaks to ensure broader compatibility. `builtins.warn` isn't always available, and `lib.genAttrs` doesn't seem to have the desired behavior.