### PR TITLE
Add chat buttons to componentEditor

### DIFF
--- a/packages/core-extensions/src/componentEditor/index.ts
+++ b/packages/core-extensions/src/componentEditor/index.ts
@@ -1,6 +1,16 @@
 import { ExtensionWebpackModule, Patch } from "@moonlight-mod/types";
 
 export const patches: Patch[] = [
+  // chat buttons
+  {
+    find: '"gift")),',
+    replace: [
+      {
+        match: /(?<=className:\i\.buttons,children:)(\i)/,
+        replacement: (_, original) => `require("componentEditor_chatButtonList").default._patchButtons(${original})`
+      }
+    ]
+  },
   // dm list
   {
     find: ".interactiveSystemDM]:",
@@ -72,6 +82,9 @@ export const patches: Patch[] = [
 ];
 
 export const webpackModules: Record<string, ExtensionWebpackModule> = {
+  chatButtonList: {
+    dependencies: [{ id: "react" }]
+  },
   dmList: {
     dependencies: [{ id: "react" }]
   },

--- a/packages/core-extensions/src/componentEditor/webpackModules/chatButtonList.tsx
+++ b/packages/core-extensions/src/componentEditor/webpackModules/chatButtonList.tsx
@@ -1,0 +1,63 @@
+import {
+  ChatButtonList,
+  ChatButtonListItem,
+  ChatButtonListAnchors,
+  ChatButtonListAnchorIndicies
+} from "@moonlight-mod/types/coreExtensions/componentEditor";
+import React from "@moonlight-mod/wp/react";
+
+const items: Record<string, ChatButtonListItem> = {};
+const itemsToRemove: Set<ChatButtonListAnchors> = new Set();
+
+function addEntries(
+  elements: React.ReactNode[],
+  entries: Record<string, ChatButtonListItem>,
+  removedEntries: Iterable<ChatButtonListAnchors>,
+  indicies: Partial<typeof ChatButtonListAnchorIndicies>,
+  props: any
+) {
+  const originalElements = [...elements];
+
+  for (const [id, entry] of Object.entries(entries)) {
+    const component = <entry.component {...props} key={id} />;
+
+    if (entry.anchor === undefined) {
+      if (entry.before) {
+        elements.splice(0, 0, component);
+      } else {
+        elements.push(component);
+      }
+    } else {
+      const index = elements.indexOf(originalElements[indicies[entry.anchor]!]);
+      elements.splice(index! + (entry.before ? 0 : 1), 0, component);
+    }
+  }
+
+  for (const id of removedEntries) {
+    if (id === undefined) {
+      continue;
+    }
+
+    const index = elements.indexOf(originalElements[indicies[id]!]);
+    elements.splice(index, 1);
+  }
+}
+
+export const chatButtonList: ChatButtonList = {
+  addButton(id, component, anchor, before = false) {
+    items[id] = {
+      component,
+      anchor,
+      before
+    };
+  },
+  removeButton(id) {
+    itemsToRemove.add(id);
+  },
+  _patchButtons(elements, props) {
+    addEntries(elements, items, itemsToRemove, ChatButtonListAnchorIndicies, props);
+    return elements;
+  }
+};
+
+export default chatButtonList;

--- a/packages/types/src/coreExtensions/componentEditor.ts
+++ b/packages/types/src/coreExtensions/componentEditor.ts
@@ -1,14 +1,7 @@
 type Patcher<T> = (elements: React.ReactNode[], props: T) => React.ReactNode[];
 
 //#region Chat Buttons
-// eslint-disable-next-line prettier/prettier
-export type ChatButtonListAnchors =
-  | "gift"
-  | "gif"
-  | "sticker"
-  | "emoji"
-  | "activity"
-  | undefined;
+export type ChatButtonListAnchors = "gift" | "gif" | "sticker" | "emoji" | "activity" | undefined;
 
 export enum ChatButtonListAnchorIndicies {
   gift = 0,

--- a/packages/types/src/coreExtensions/componentEditor.ts
+++ b/packages/types/src/coreExtensions/componentEditor.ts
@@ -1,5 +1,40 @@
 type Patcher<T> = (elements: React.ReactNode[], props: T) => React.ReactNode[];
 
+//#region Chat Buttons
+// eslint-disable-next-line prettier/prettier
+export type ChatButtonListAnchors =
+  | "gift"
+  | "gif"
+  | "sticker"
+  | "emoji"
+  | "activity"
+  | undefined;
+
+export enum ChatButtonListAnchorIndicies {
+  gift = 0,
+  "gif",
+  "sticker",
+  "emoji",
+  "activity"
+}
+
+export type ChatButtonListItem = {
+  component: React.FC<any>;
+  anchor: ChatButtonListAnchors;
+  before: boolean;
+};
+
+export type ChatButtonList = {
+  addButton: (id: string, component: React.FC<any>, anchor?: ChatButtonListAnchors, before?: boolean) => void;
+  removeButton: (id: ChatButtonListAnchors) => void;
+  //TODO: fix props type
+  /**
+   * @private
+   */
+  _patchButtons: Patcher<any>;
+};
+//#endregion
+
 //#region DM List
 export type DMListAnchors =
   | "content"
@@ -160,6 +195,10 @@ export type Messages = {
   _patchAccessories: Patcher<any>;
 };
 //#endregion
+
+export type ChatButtonListExports = {
+  default: ChatButtonList;
+};
 
 export type DMListExports = {
   default: DMList;

--- a/packages/types/src/discord/require.ts
+++ b/packages/types/src/discord/require.ts
@@ -2,6 +2,7 @@ import { Exports as AppPanels } from "../coreExtensions/appPanels";
 import { Exports as Commands } from "../coreExtensions/commands";
 import { ErrorBoundaryExports as ErrorBoundary, IconsExports as Icons } from "../coreExtensions/common";
 import {
+  ChatButtonListExports as ChatButtonList,
   DMListExports as DMList,
   MemberListExports as MemberList,
   MessagesExports as Messages
@@ -23,6 +24,7 @@ declare function WebpackRequire(id: "commands_commands"): Commands;
 declare function WebpackRequire(id: "common_ErrorBoundary"): ErrorBoundary;
 declare function WebpackRequire(id: "common_icons"): Icons;
 
+declare function WebpackRequire(id: "componentEditor_chatButtonList"): ChatButtonList;
 declare function WebpackRequire(id: "componentEditor_dmList"): DMList;
 declare function WebpackRequire(id: "componentEditor_memberList"): MemberList;
 declare function WebpackRequire(id: "componentEditor_messages"): Messages;

--- a/packages/types/src/import.d.ts
+++ b/packages/types/src/import.d.ts
@@ -40,6 +40,12 @@ declare module "@moonlight-mod/wp/common_icons" {
 }
 declare module "@moonlight-mod/wp/common_stores";
 
+declare module "@moonlight-mod/wp/componentEditor_chatButtonList" {
+  import { CoreExtensions } from "@moonlight-mod/types";
+
+  const _default: CoreExtensions.ComponentEditor.ChatButtonList;
+  export default _default;
+}
 declare module "@moonlight-mod/wp/componentEditor_dmList" {
   import { CoreExtensions } from "@moonlight-mod/types";
 


### PR DESCRIPTION
Prettier complains about [this line](https://github.com/Enovale/moonlight/blob/7bf85da6e60be528f2ba149a9c57d83a7edb0294/packages/types/src/coreExtensions/componentEditor.ts#L5) because its not as long as the later lines, but I thought for consistency's sake it should not be shortened. 