### PR TITLE
Publish browser-related builds in Github releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,14 +28,42 @@ jobs:
           MOONLIGHT_BRANCH: stable
           MOONLIGHT_VERSION: ${{ github.ref_name }}
         run: pnpm run build
-      - name: Create archive
+
+      - name: Build moonlight (mv3)
+        env:
+          NODE_ENV: production
+          MOONLIGHT_BRANCH: stable
+          MOONLIGHT_VERSION: ${{ github.ref_name }}
+        run: pnpm run browser
+
+      - name: Build moonlight (mv2)
+        env:
+          NODE_ENV: production
+          MOONLIGHT_BRANCH: stable
+          MOONLIGHT_VERSION: ${{ github.ref_name }}
+        run: pnpm run browser-mv2
+
+      - name: Separate browser builds
+        run: |
+          mv ./dist/browser ./browser
+          mv ./dist/browser-mv2 ./browser-mv2
+
+      - name: Copy browser's index.js to browser.js
+        run: |
+          cp ./browser/index.js ./browser.js
+
+      - name: Create archives
         run: |
           cd ./dist
           tar -czf ../dist.tar.gz *
+          cd ../browser
+          tar -czf ../browser.tar.gz *
+          cd ../browser-mv2
+          tar -czf ../browser-mv2.tar.gz *
           cd ..
 
       - name: Deploy to GitHub
         uses: ncipollo/release-action@v1
         with:
-          artifacts: ./dist.tar.gz
+          artifacts: "dist.tar.gz,browser.tar.gz,browser-mv2.tar.gz,browser.js"
           bodyFile: ./CHANGELOG.md


### PR DESCRIPTION
Adds manifest v2 and v3 builds, as well as a standalone `browser.js`, to the list of files released:

<img width="738" height="797" alt="image" src="https://github.com/user-attachments/assets/a8612fa6-07cd-486a-9f3f-2cd06379f76a" />

Closes #273 