### PR TITLE
nix: leverage systems flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,7 +18,23 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,23 +3,19 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    systems.url = "github:nix-systems/default";
   };
 
   outputs =
     {
       self,
       nixpkgs,
+      systems,
     }:
     let
       overlay = import ./nix/overlay.nix { inherit self; };
       inherit (nixpkgs) lib;
-      systems = [
-        "aarch64-linux"
-        "aarch64-darwin"
-        "x86_64-darwin"
-        "x86_64-linux"
-      ];
-      forAllSystems = lib.genAttrs systems;
+      forAllSystems = lib.genAttrs (import systems);
     in
     let
       # Deprecated


### PR DESCRIPTION
Added nix system's flake for the purpose of allowing downstream consumers narrow or extend the supported systems of this flake. For more information, kindly see https://github.com/nix-systems/nix-systems