### PR TITLE
Fix eval of deprecated packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
             self.packages.${system}.moonlight;
 
         # Deprecated packages
-        inherit (overlay-pkgs)
+        inherit (overlay-pkgs.${system})
           discord
           discord-ptb
           discord-canary

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -8,18 +8,17 @@ prev.lib.genAttrs
     "discord-canary"
     "discord-development"
   ]
-  (name: {
-    inherit name;
-    value =
-      prev.lib.warn
-        ''
-          The moonlight package '${name}' is deprecated and will be removed in a future release.
-          Please use 'discord.override {withMoonlight = true;}' instead.
-          For instructions see: https://moonlight-mod.github.io/using/install/#nixpkgs
-        ''
-        prev.${name}.override
-        {
-          withMoonlight = true;
-          moonlight = self.packages.${prev.system}.moonlight;
-        };
-  })
+  (
+    name:
+    prev.lib.warn
+      ''
+        The moonlight package '${name}' is deprecated and will be removed in a future release.
+        Please use 'discord.override {withMoonlight = true;}' instead.
+        For instructions see: https://moonlight-mod.github.io/using/install/#nixpkgs
+      ''
+      prev.${name}.override
+      {
+        withMoonlight = true;
+        moonlight = self.packages.${prev.system}.moonlight;
+      }
+  )


### PR DESCRIPTION
resolves two problems:

- the second argument to `genAttrs` should just produce a value, not an attrset with `name` and `value`
- `overlay-packages` in flake.nix is keyed by system, on account of the use of `forAllSystems`

this fixes `nix flake show` being broken.

I guess this got broken in #258? somewhat amusing that apparently nobody noticed.