### PR TITLE
fix(core-extensions/componentEditor): update chat button list patch

### DIFF
--- a/packages/core-extensions/src/componentEditor/index.ts
+++ b/packages/core-extensions/src/componentEditor/index.ts
@@ -3,10 +3,10 @@ import { ExtensionWebpackModule, Patch } from "@moonlight-mod/types";
 export const patches: Patch[] = [
   // chat buttons
   {
-    find: '"gift")),',
+    find: '"gift")}),',
     replace: [
       {
-        match: /(?<=className:\i\.buttons,children:)(\i)/,
+        match: /(?<=className:\i\(\)\(\i\.buttons,\{\[\i\.reducedGap\]:\i\}\),children:)(\i)/,
         replacement: (_, original) => `require("componentEditor_chatButtonList").default._patchButtons(${original})`
       }
     ]

--- a/packages/core-extensions/src/componentEditor/webpackModules/chatButtonList.tsx
+++ b/packages/core-extensions/src/componentEditor/webpackModules/chatButtonList.tsx
@@ -1,8 +1,7 @@
 import {
   ChatButtonList,
   ChatButtonListItem,
-  ChatButtonListAnchors,
-  ChatButtonListAnchorIndicies
+  ChatButtonListAnchors
 } from "@moonlight-mod/types/coreExtensions/componentEditor";
 import React from "@moonlight-mod/wp/react";
 
@@ -12,14 +11,10 @@ const itemsToRemove: Set<ChatButtonListAnchors> = new Set();
 function addEntries(
   elements: React.ReactNode[],
   entries: Record<string, ChatButtonListItem>,
-  removedEntries: Iterable<ChatButtonListAnchors>,
-  indicies: Partial<typeof ChatButtonListAnchorIndicies>,
-  props: any
+  removedEntries: Iterable<ChatButtonListAnchors>
 ) {
-  const originalElements = [...elements];
-
   for (const [id, entry] of Object.entries(entries)) {
-    const component = <entry.component {...props} key={id} />;
+    const component = <entry.component key={id} />;
 
     if (entry.anchor === undefined) {
       if (entry.before) {
@@ -28,7 +23,7 @@ function addEntries(
         elements.push(component);
       }
     } else {
-      const index = elements.indexOf(originalElements[indicies[entry.anchor]!]);
+      const index = elements.findIndex((elem) => (elem as React.ReactElement).key === entry.anchor);
       elements.splice(index! + (entry.before ? 0 : 1), 0, component);
     }
   }
@@ -38,7 +33,7 @@ function addEntries(
       continue;
     }
 
-    const index = elements.indexOf(originalElements[indicies[id]!]);
+    const index = elements.findIndex((elem) => (elem as React.ReactElement).key === id);
     elements.splice(index, 1);
   }
 }
@@ -54,8 +49,9 @@ export const chatButtonList: ChatButtonList = {
   removeButton(id) {
     itemsToRemove.add(id);
   },
-  _patchButtons(elements, props) {
-    addEntries(elements, items, itemsToRemove, ChatButtonListAnchorIndicies, props);
+  _patchButtons(elements) {
+    addEntries(elements, items, itemsToRemove);
+
     return elements;
   }
 };


### PR DESCRIPTION
updates the chat button list patch to reflect changes made by the `2025-09-chat-input-ia-desktop` experiment

this in turn fixes the `cleanChatBar` extension

| `moolight` @ `develop` | `arhsm/moonlight` @ `fix/core-extensions/componentEditor` |
|:----------------------:|:---------------------------------------------------------:|
| <img width="706" height="71" alt="2025-11-21_00-43-50" src="https://github.com/user-attachments/assets/71ce644e-cfc2-4abc-a55e-f9714c786add" /> | <img width="723" height="63" alt="2025-11-21_01-55-09" src="https://github.com/user-attachments/assets/377d3064-545a-4ba2-9e6e-7ae7d2b6f30a" /> |

I haven't touched the types but this experiment makes `ChatButtonListAnchorIndicies` useless/redundant and `ChatButtonListAnchors` seems to be missing things such as `upload`, `spacer`, `confetti`, `appLauncher`, `submit`

<img width="417" height="835" alt="2025-11-21_01-56-49" src="https://github.com/user-attachments/assets/a60d7cef-9ac5-4d89-b4ad-b126c9711357" />