### PR TITLE
nix: fix pnpmDeps hash

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -4,7 +4,6 @@
   nodejs_22,
   pnpm_10,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "moonlight";
   version = (builtins.fromJSON (builtins.readFile ./../package.json)).version;
@@ -24,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 1;
-    hash = "sha256-HWsZf9SUXenKHV+1Ut7inhQe1Rf74V0TeDFNRmWL9C0=";
+    hash = "sha256-woLslstRJJa7Y/nqdqZ01mUSlnUZy6FLVjNDBG9CmM0=";
   };
 
   env = {
@@ -56,6 +55,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Yet another Discord mod";
     homepage = "https://moonlight-mod.github.io/";
     license = licenses.lgpl3;
-    maintainers = with maintainers; [ notnite ];
+    maintainers = with maintainers; [notnite];
   };
 })


### PR DESCRIPTION
Fix broken nix by updating `pnpmDeps` hash 