### PR TITLE
fix(core-extensions/contextMenu): update `__contextMenu_parse` patch

### DIFF
--- a/packages/core-extensions/src/contextMenu/index.tsx
+++ b/packages/core-extensions/src/contextMenu/index.tsx
@@ -9,7 +9,7 @@ export const patches: Patch[] = [
         replacement: (items, props) => `require("contextMenu_contextMenu")._patchMenu(${props},${items})`
       },
       {
-        match: /(?<=})(?=function (\i)\((\i)\){return \i\(\2\)\.)/,
+        match: /(?<=})(?=function (\i)\((\i),\i\){return \i\(\2\)\.)/,
         replacement: (_, name) => `exports.__contextMenu_parse=${name};`
       }
     ]


### PR DESCRIPTION
the `__contextMenu_parse` function now has an extra parameter, its a boolean as far as I can tell, other than that I didn't bother figuring out the purpose of it or add it to types.

this fixes the hard crash when opening any context menu in the latest (`canary 472543 (604f20f)` at the time of writing) client.